### PR TITLE
IBX-1699: Bump defaults and requirements for Solr

### DIFF
--- a/bin/.travis/init_solr.sh
+++ b/bin/.travis/init_solr.sh
@@ -16,7 +16,7 @@ default_shards=('shard0')
 
 SOLR_PORT=${SOLR_PORT:-8983}
 SOLR_DIR=${SOLR_DIR:-'__solr'}
-SOLR_VERSION=${SOLR_VERSION:-'7.7.3'}
+SOLR_VERSION=${SOLR_VERSION:-'8.11.1'}
 SOLR_INSTALL_DIR="${SOLR_DIR}/${SOLR_VERSION}"
 SOLR_DEBUG=${SOLR_DEBUG:-false}
 SOLR_HOME=${SOLR_HOME:-'ezcloud'}
@@ -132,7 +132,7 @@ wait_for_solr(){
     done
 }
 
-# Run for Solr 7
+# Run for Solr 7+
 solr_run() {
     echo "Running with version ${SOLR_VERSION} in standalone mode"
     echo "Starting solr on port ${SOLR_PORT}..."
@@ -144,7 +144,7 @@ solr_run() {
     solr_create_cores
 }
 
-# Create cores for Solr 7
+# Create cores for Solr 7+
 solr_create_cores() {
     home_dir="${SOLR_INSTALL_DIR}/server/${SOLR_HOME}"
     template_dir="${home_dir}/template"

--- a/bin/generate-solr-config.sh
+++ b/bin/generate-solr-config.sh
@@ -3,8 +3,8 @@
 set -e
 
 # Default paramters, if not overloaded by user arguments
-DESTINATION_DIR=.platform/configsets/solr6/conf
-SOLR_VERSION=7.7.2
+DESTINATION_DIR=.platform/configsets/solr8/conf
+SOLR_VERSION=8.11.1
 FORCE=false
 SOLR_INSTALL_DIR=""
 
@@ -19,8 +19,8 @@ Help (this text):
 
 Usage with eZ Platform Cloud (arguments here can be skipped as they have default values):
 ./vendor/ibexa/solr/bin/generate-solr-config.sh \\
-  --destination-dir=.platform/configsets/solr6/conf \\
-  --solr-version=7.7.2
+  --destination-dir=.platform/configsets/solr8/conf \\
+  --solr-version=8.11.1
 
 Usage with on-premise version of Solr:
 ./vendor/ibexa/solr/bin/generate-solr-config.sh \\
@@ -33,7 +33,7 @@ Warning:
 
 Arguments:
   [--destination-dir=<dest.dir>]     : Location where solr config should be stored
-                                       Default value is .platform/configsets/solr6/conf
+                                       Default value is .platform/configsets/solr8/conf
   [-f|--force]                       : Overwrite destination-dir if it already exists
   [--solr-install-dir]               : Existing downloaded Solr install to copy base config from.
   [--solr-version]                   : Solr version to download & copy base config from, used only if --solr-install-dir is unset


### PR DESCRIPTION
| Question                                  | Answer
| ----------------------------------------- | ------------------
| **JIRA issue**                            | [IBX-1699](https://issues.ibexa.co/browse/IBX-1699)
| **Type**                                  | improvement
| **Target Ibexa DXP version**              | `v3.3`
| **BC breaks**                             | TBD

Upgrade default Solr install to 8.11.1, with the log4j fix.

Work in progress:
- [x] Install Solr 8.11.1
- [x] ~Nothing for Java yet~ Disregard, separate install. Doc update only.