### PR TITLE
Added missing entry for Ibexa\Tests\Solr in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
     "autoload-dev": {
         "psr-4": {
             "Ibexa\\Tests\\Bundle\\Solr\\": "tests/bundle/",
+            "Ibexa\\Tests\\Solr\\": "tests/lib/",
             "EzSystems\\EzPlatformSolrSearchEngine\\Tests\\": "tests/lib/",
             "EzSystems\\EzPlatformSolrSearchEngineBundle\\Tests\\": "tests/bundle/",
             "Ibexa\\Tests\\Integration\\Core\\": "vendor/ibexa/core/tests/integration/Core/",


### PR DESCRIPTION

```
➜  solr git:(main) ✗ php vendor/bin/phpunit --bootstrap tests/bootstrap.php
PHP Fatal error:  Uncaught Error: Class 'Ibexa\Tests\Solr\Search\TestCase' not found in /home/adamwojs/ibexa/solr/tests/lib/Search/FieldMapper/BoostFactorProviderTest.php:17
Stack trace:
#0 /home/adamwojs/ibexa/solr/vendor/phpunit/phpunit/src/Util/FileLoader.php(66): include_once()
#1 /home/adamwojs/ibexa/solr/vendor/phpunit/phpunit/src/Util/FileLoader.php(54): PHPUnit\Util\FileLoader::load()
#2 /home/adamwojs/ibexa/solr/vendor/phpunit/phpunit/src/Framework/TestSuite.php(384): PHPUnit\Util\FileLoader::checkAndLoad()
#3 /home/adamwojs/ibexa/solr/vendor/phpunit/phpunit/src/Framework/TestSuite.php(482): PHPUnit\Framework\TestSuite->addTestFile()
#4 /home/adamwojs/ibexa/solr/vendor/phpunit/phpunit/src/Util/Configuration.php(1031): PHPUnit\Framework\TestSuite->addTestFiles()
#5 /home/adamwojs/ibexa/solr/vendor/phpunit/phpunit/src/Util/Configuration.php(900): PHPUnit\Util\Configuration->getTestSuite()
#6 /home/adamwojs/ibexa/solr/vendor/phpunit/phpunit/src/TextUI/Command.php(963): PHPUnit\Util\Configuration->getTestSuiteConfiguratio in /home/adamwojs/ibexa/solr/tests/lib/Search/FieldMapper/BoostFactorProviderTest.php on line 17

```