### PR TITLE
IBX-1694: Rebranded dependency injection container service tags

### DIFF
--- a/doc/specifications/document_field_mappers.md
+++ b/doc/specifications/document_field_mappers.md
@@ -42,19 +42,19 @@ as follows:
 
 - all block documents
     - `ContentFieldMapper`
-    - `ezpublish.search.solr.document_field_mapper.block`
+    - `ibexa.search.solr.field.mapper.block`
 - all block documents per translation
     - `ContentTranslationFieldMapper`
-    - `ezpublish.search.solr.field_mapper.block_translation`
+    - `ibexa.search.solr.field.mapper.block.translation`
 - Content documents
     - `ContentFieldMapper`
-    - `ezpublish.search.solr.document_field_mapper.content`
+    - `ibexa.search.solr.field.mapper.content`
 - Content documents per translation
     - `ContentTranslationFieldMapper`
-    - `ezpublish.search.solr.field_mapper.content_translation`
+    - `ibexa.search.solr.field.mapper.content.translation`
 - Location documents
     - `LocationFieldMapper`
-    - `ezpublish.search.solr.field_mapper.location`
+    - `ibexa.search.solr.field.mapper.location`
 
 The following example shows how to index data from the parent Location content, in order to make it
 available for full text search on the children content. A concrete use case could be indexing
@@ -130,5 +130,5 @@ my_webinar_app.webinar_event_title_fulltext_field_mapper:
         - '@ezpublish.spi.persistence.content_handler'
         - '@ezpublish.spi.persistence.location_handler'
     tags:
-        - {name: ezpublish.search.solr.field_mapper.content}
+        - {name: ibexa.search.solr.field.mapper.content}
 ```

--- a/src/bundle/DependencyInjection/IbexaSolrExtension.php
+++ b/src/bundle/DependencyInjection/IbexaSolrExtension.php
@@ -62,7 +62,7 @@ class IbexaSolrExtension extends Extension
      *
      * @var string
      */
-    public const ENDPOINT_TAG = 'ezpublish.search.solr.endpoint';
+    public const ENDPOINT_TAG = 'ibexa.search.solr.endpoint';
 
     /**
      * @var string
@@ -189,7 +189,7 @@ class IbexaSolrExtension extends Extension
         // Core filter
         $coreFilterDefinition = new ChildDefinition(self::CORE_FILTER_ID);
         $coreFilterDefinition->replaceArgument(0, new Reference($endpointResolverId));
-        $coreFilterDefinition->addTag('ezpublish.search.solr.core_filter', ['connection' => $connectionName]);
+        $coreFilterDefinition->addTag('ibexa.search.solr.core.filter', ['connection' => $connectionName]);
         $coreFilterId = "$alias.connection.$connectionName.core_filter_id";
         $container->setDefinition($coreFilterId, $coreFilterDefinition);
 
@@ -215,7 +215,7 @@ class IbexaSolrExtension extends Extension
         $gatewayDefinition = new ChildDefinition(self::GATEWAY_ID);
         $gatewayDefinition->replaceArgument(1, new Reference($endpointResolverId));
         $gatewayDefinition->replaceArgument(6, new Reference($distributionStrategyId));
-        $gatewayDefinition->addTag('ezpublish.search.solr.gateway', ['connection' => $connectionName]);
+        $gatewayDefinition->addTag('ibexa.search.solr.gateway', ['connection' => $connectionName]);
 
         $gatewayId = "$alias.connection.$connectionName.gateway_id";
         $container->setDefinition($gatewayId, $gatewayDefinition);

--- a/src/lib/Container/Compiler/AggregateCriterionVisitorPass.php
+++ b/src/lib/Container/Compiler/AggregateCriterionVisitorPass.php
@@ -31,7 +31,7 @@ class AggregateCriterionVisitorPass implements CompilerPassInterface
             );
 
             $visitors = $container->findTaggedServiceIds(
-                'ezpublish.search.solr.query.content.criterion_visitor'
+                'ibexa.search.solr.query.content.criterion.visitor'
             );
 
             $this->addHandlers($aggregateContentCriterionVisitorDefinition, $visitors);
@@ -43,7 +43,7 @@ class AggregateCriterionVisitorPass implements CompilerPassInterface
             );
 
             $visitors = $container->findTaggedServiceIds(
-                'ezpublish.search.solr.query.location.criterion_visitor'
+                'ibexa.search.solr.query.location.criterion.visitor'
             );
 
             $this->addHandlers($aggregateLocationCriterionVisitorDefinition, $visitors);

--- a/src/lib/Container/Compiler/AggregateSortClauseVisitorPass.php
+++ b/src/lib/Container/Compiler/AggregateSortClauseVisitorPass.php
@@ -34,7 +34,7 @@ class AggregateSortClauseVisitorPass implements CompilerPassInterface
             );
 
             $visitors = $container->findTaggedServiceIds(
-                'ezpublish.search.solr.query.content.sort_clause_visitor'
+                'ibexa.search.solr.query.content.sort_clause.visitor'
             );
 
             $this->addHandlers($aggregateContentSortClauseVisitorDefinition, $visitors);
@@ -46,7 +46,7 @@ class AggregateSortClauseVisitorPass implements CompilerPassInterface
             );
 
             $visitors = $container->findTaggedServiceIds(
-                'ezpublish.search.solr.query.location.sort_clause_visitor'
+                'ibexa.search.solr.query.location.sort_clause.visitor'
             );
 
             $this->addHandlers($aggregateLocationSortClauseVisitorDefinition, $visitors);

--- a/src/lib/Container/Compiler/CoreFilterRegistryPass.php
+++ b/src/lib/Container/Compiler/CoreFilterRegistryPass.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 final class CoreFilterRegistryPass implements CompilerPassInterface
 {
-    public const CORE_FILTER_SERVICE_TAG = 'ezpublish.search.solr.core_filter';
+    public const CORE_FILTER_SERVICE_TAG = 'ibexa.search.solr.core.filter';
 
     public function process(ContainerBuilder $container): void
     {
@@ -30,7 +30,7 @@ final class CoreFilterRegistryPass implements CompilerPassInterface
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['connection'])) {
                     throw new LogicException(
-                        "'ezpublish.search.solr.core_filter' service tag needs a 'connection' attribute " .
+                        "'ibexa.search.solr.core.filter' service tag needs a 'connection' attribute " .
                         'to identify the Gateway.'
                     );
                 }

--- a/src/lib/Container/Compiler/EndpointRegistryPass.php
+++ b/src/lib/Container/Compiler/EndpointRegistryPass.php
@@ -35,13 +35,13 @@ class EndpointRegistryPass implements CompilerPassInterface
             'ezpublish.search.solr.gateway.endpoint_registry'
         );
 
-        $endpoints = $container->findTaggedServiceIds('ezpublish.search.solr.endpoint');
+        $endpoints = $container->findTaggedServiceIds('ibexa.search.solr.endpoint');
 
         foreach ($endpoints as $id => $attributes) {
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['alias'])) {
                     throw new LogicException(
-                        "'ezpublish.search.solr.endpoint' service tag needs an 'alias' attribute " .
+                        "'ibexa.search.solr.endpoint' service tag needs an 'alias' attribute " .
                         'to identify the endpoint.'
                     );
                 }

--- a/src/lib/Container/Compiler/FieldMapperPass/BlockFieldMapperPass.php
+++ b/src/lib/Container/Compiler/FieldMapperPass/BlockFieldMapperPass.php
@@ -13,7 +13,7 @@ use Ibexa\Solr\Container\Compiler\BaseFieldMapperPass;
  */
 class BlockFieldMapperPass extends BaseFieldMapperPass
 {
-    public const AGGREGATE_MAPPER_SERVICE_ID = 'ezpublish.search.solr.field_mapper.block';
+    public const AGGREGATE_MAPPER_SERVICE_ID = 'ibexa.search.solr.field.mapper.block';
     public const AGGREGATE_MAPPER_SERVICE_TAG = self::AGGREGATE_MAPPER_SERVICE_ID;
 }
 

--- a/src/lib/Container/Compiler/FieldMapperPass/BlockTranslationFieldMapperPass.php
+++ b/src/lib/Container/Compiler/FieldMapperPass/BlockTranslationFieldMapperPass.php
@@ -14,7 +14,7 @@ use Ibexa\Solr\Container\Compiler\BaseFieldMapperPass;
  */
 class BlockTranslationFieldMapperPass extends BaseFieldMapperPass
 {
-    public const AGGREGATE_MAPPER_SERVICE_ID = 'ezpublish.search.solr.field_mapper.block_translation';
+    public const AGGREGATE_MAPPER_SERVICE_ID = 'ibexa.search.solr.field.mapper.block.translation';
     public const AGGREGATE_MAPPER_SERVICE_TAG = self::AGGREGATE_MAPPER_SERVICE_ID;
 }
 

--- a/src/lib/Container/Compiler/FieldMapperPass/ContentFieldMapperPass.php
+++ b/src/lib/Container/Compiler/FieldMapperPass/ContentFieldMapperPass.php
@@ -13,7 +13,7 @@ use Ibexa\Solr\Container\Compiler\BaseFieldMapperPass;
  */
 class ContentFieldMapperPass extends BaseFieldMapperPass
 {
-    public const AGGREGATE_MAPPER_SERVICE_ID = 'ezpublish.search.solr.field_mapper.content';
+    public const AGGREGATE_MAPPER_SERVICE_ID = 'ibexa.search.solr.field.mapper.content';
     public const AGGREGATE_MAPPER_SERVICE_TAG = self::AGGREGATE_MAPPER_SERVICE_ID;
 }
 

--- a/src/lib/Container/Compiler/FieldMapperPass/ContentTranslationFieldMapperPass.php
+++ b/src/lib/Container/Compiler/FieldMapperPass/ContentTranslationFieldMapperPass.php
@@ -14,7 +14,7 @@ use Ibexa\Solr\Container\Compiler\BaseFieldMapperPass;
  */
 class ContentTranslationFieldMapperPass extends BaseFieldMapperPass
 {
-    public const AGGREGATE_MAPPER_SERVICE_ID = 'ezpublish.search.solr.field_mapper.content_translation';
+    public const AGGREGATE_MAPPER_SERVICE_ID = 'ibexa.search.solr.field.mapper.content.translation';
     public const AGGREGATE_MAPPER_SERVICE_TAG = self::AGGREGATE_MAPPER_SERVICE_ID;
 }
 

--- a/src/lib/Container/Compiler/FieldMapperPass/LocationFieldMapperPass.php
+++ b/src/lib/Container/Compiler/FieldMapperPass/LocationFieldMapperPass.php
@@ -13,7 +13,7 @@ use Ibexa\Solr\Container\Compiler\BaseFieldMapperPass;
  */
 class LocationFieldMapperPass extends BaseFieldMapperPass
 {
-    public const AGGREGATE_MAPPER_SERVICE_ID = 'ezpublish.search.solr.field_mapper.location';
+    public const AGGREGATE_MAPPER_SERVICE_ID = 'ibexa.search.solr.field.mapper.location';
     public const AGGREGATE_MAPPER_SERVICE_TAG = self::AGGREGATE_MAPPER_SERVICE_ID;
 }
 

--- a/src/lib/Container/Compiler/GatewayRegistryPass.php
+++ b/src/lib/Container/Compiler/GatewayRegistryPass.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 final class GatewayRegistryPass implements CompilerPassInterface
 {
-    public const GATEWAY_SERVICE_TAG = 'ezpublish.search.solr.gateway';
+    public const GATEWAY_SERVICE_TAG = 'ibexa.search.solr.gateway';
 
     public function process(ContainerBuilder $container): void
     {
@@ -30,7 +30,7 @@ final class GatewayRegistryPass implements CompilerPassInterface
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['connection'])) {
                     throw new LogicException(
-                        "'ezpublish.search.solr.gateway' service tag needs a 'connection' attribute " .
+                        "'ibexa.search.solr.gateway' service tag needs a 'connection' attribute " .
                         'to identify the Gateway.'
                     );
                 }

--- a/src/lib/Resources/config/container/solr.yml
+++ b/src/lib/Resources/config/container/solr.yml
@@ -151,7 +151,7 @@ services:
             - "@ezpublish.search.solr.result_extractor.location"
             - "@ezpublish.search.solr.core_filter"
         tags:
-            - {name: ezplatform.search_engine, alias: solr}
+            - {name: ibexa.search.engine, alias: solr}
         lazy: true
 
     ezpublish.spi.search.solr.indexer:
@@ -162,6 +162,6 @@ services:
             $connection: "@ezpublish.persistence.connection"
             $searchHandler: "@ezpublish.spi.search.solr"
         tags:
-            - {name: ezplatform.search_engine.indexer, alias: solr}
+            - {name: ibexa.search.engine.indexer, alias: solr}
         lazy: true
 

--- a/src/lib/Resources/config/container/solr/aggregation_result_extractors.yml
+++ b/src/lib/Resources/config/container/solr/aggregation_result_extractors.yml
@@ -7,12 +7,12 @@ services:
   ezpublish.search.solr.query.content.aggregation_result_extractor.dispatcher:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\DispatcherAggregationResultExtractor
     arguments:
-      $extractors: !tagged ezplatform.search.solr.query.content.aggregation_result_extractor
+      $extractors: !tagged ibexa.search.solr.query.content.aggregation.result.extractor
 
   ezpublish.search.solr.query.location.aggregation_result_extractor.dispatcher:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\DispatcherAggregationResultExtractor
     arguments:
-      $extractors: !tagged ezplatform.search.solr.query.location.aggregation_result_extractor
+      $extractors: !tagged ibexa.search.solr.query.location.aggregation.result.extractor
 
   ### Key mappers
 
@@ -64,8 +64,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\ContentTypeTermAggregation'
       $keyMapper: '@Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\ContentTypeAggregationKeyMapper'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.content_type_group_term:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
@@ -73,8 +73,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\ContentTypeGroupTermAggregation'
       $keyMapper: '@Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\ContentTypeGroupAggregationKeyMapper'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.data_metadata_range:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\RangeAggregationResultExtractor
@@ -82,8 +82,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\DateMetadataRangeAggregation'
       $keyMapper: '@Ibexa\Solr\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\DateTimeRangeAggregationKeyMapper'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.langauge_term:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
@@ -91,8 +91,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\LanguageTermAggregation'
       $keyMapper: '@Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\LanguageAggregationKeyMapper'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.raw_range:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\RangeAggregationResultExtractor
@@ -100,24 +100,24 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\RawRangeAggregation'
       $keyMapper: '@Ibexa\Solr\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\NullRangeAggregationKeyMapper'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.raw_stats:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\StatsAggregationResultExtractor
     arguments:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\RawStatsAggregation'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.raw_term:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
     arguments:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\RawTermAggregation'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.object_state_term:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
@@ -125,8 +125,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\ObjectStateTermAggregation'
       $keyMapper: '@Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\ObjectStateAggregationKeyMapper'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.section_term:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
@@ -134,8 +134,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\SectionTermAggregation'
       $keyMapper: '@Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\SectionAggregationKeyMapper'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.subtree_term:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
@@ -143,8 +143,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Location\SubtreeTermAggregation'
       $keyMapper: '@Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\SubtreeAggregationKeyMapper'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.location_children_term:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
@@ -152,7 +152,7 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Location\LocationChildrenTermAggregation'
       $keyMapper: '@Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\LocationAggregationKeyMapper'
     tags:
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.subtree_term.nested:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\NestedAggregationResultExtractor
@@ -167,8 +167,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\UserMetadataTermAggregation'
       $keyMapper: '@Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\UserMetadataAggregationKeyMapper'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.field.author_term:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
@@ -176,8 +176,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\AuthorTermAggregation'
       $keyMapper: '@Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\AuthorAggregationKeyMapper'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.field.checkbox_term:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
@@ -185,8 +185,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\CheckboxTermAggregation'
       $keyMapper: '@Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\BooleanAggregationKeyMapper'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.field.country:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
@@ -194,8 +194,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\CountryTermAggregation'
       $keyMapper: '@Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\CountryAggregationKeyMapper'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.field.date_range:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\RangeAggregationResultExtractor
@@ -203,8 +203,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\DateRangeAggregation'
       $keyMapper: '@Ibexa\Solr\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\DateTimeRangeAggregationKeyMapper'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.field.datetime_range:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\RangeAggregationResultExtractor
@@ -212,8 +212,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\DateTimeRangeAggregation'
       $keyMapper: '@Ibexa\Solr\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\DateTimeRangeAggregationKeyMapper'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.field.float_range:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\RangeAggregationResultExtractor
@@ -221,16 +221,16 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\FloatRangeAggregation'
       $keyMapper: '@Ibexa\Solr\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\FloatRangeAggregationKeyMapper'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.field.float_stats:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\StatsAggregationResultExtractor
     arguments:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\FloatStatsAggregation'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.field.integer_range:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\RangeAggregationResultExtractor
@@ -238,32 +238,32 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\IntegerRangeAggregation'
       $keyMapper: '@Ibexa\Solr\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\IntRangeAggregationKeyMapper'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.field.integer_stats:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\StatsAggregationResultExtractor
     arguments:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\IntegerStatsAggregation'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.field.keyword_term:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
     arguments:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\KeywordTermAggregation'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.field.selection_term:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
     arguments:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\SelectionTermAggregation'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.field.time_range:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\RangeAggregationResultExtractor
@@ -271,8 +271,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\TimeRangeAggregation'
       $keyMapper: '@Ibexa\Solr\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\IntRangeAggregationKeyMapper'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }
 
   ### Content specific
 
@@ -282,7 +282,7 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\VisibilityTermAggregation'
       $keyMapper: '@Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\BooleanAggregationKeyMapper'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.content.aggregation.result.extractor }
 
   ### Location specific
 
@@ -292,4 +292,4 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\VisibilityTermAggregation'
       $keyMapper: '@Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\InvertedBooleanAggregationKeyMapper'
     tags:
-      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+      - { name: ibexa.search.solr.query.location.aggregation.result.extractor }

--- a/src/lib/Resources/config/container/solr/aggregation_visitors.yml
+++ b/src/lib/Resources/config/container/solr/aggregation_visitors.yml
@@ -7,12 +7,12 @@ services:
   ezpublish.search.solr.query.content.aggregation_visitor.dispatcher:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\DispatcherAggregationVisitor
     arguments:
-      $visitors: !tagged ezplatform.search.solr.query.content.aggregation_visitor
+      $visitors: !tagged ibexa.search.solr.query.content.aggregation.visitor
 
   ezpublish.search.solr.query.location.aggregation_visitor.dispatcher:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\DispatcherAggregationVisitor
     arguments:
-      $visitors: !tagged ezplatform.search.solr.query.location.aggregation_visitor
+      $visitors: !tagged ibexa.search.solr.query.location.aggregation.visitor
 
   ### Factories
 
@@ -33,8 +33,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\ContentTypeTermAggregation'
       $searchIndexFieldName: 'content_type_id_id'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ezpublish.search.solr.query.common.aggregation_visitor.content_type_group:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\TermAggregationVisitor
@@ -43,8 +43,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\ContentTypeGroupTermAggregation'
       $searchIndexFieldName: 'content_type_group_ids_mid'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ezpublish.search.solr.query.common.aggregation_visitor.field.author_term:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\TermAggregationVisitor
@@ -53,8 +53,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\AuthorTermAggregation'
       $searchIndexFieldName: 'aggregation_value'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ezpublish.search.solr.query.common.aggregation_visitor.field.checkbox_term:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\TermAggregationVisitor
@@ -63,8 +63,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\CheckboxTermAggregation'
       $searchIndexFieldName: 'value'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ezpublish.search.solr.query.common.aggregation_visitor.field.date_range:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\RangeAggregationVisitor
@@ -73,8 +73,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\DateRangeAggregation'
       $searchIndexFieldName: 'value'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ezpublish.search.solr.query.common.aggregation_visitor.field.datetime_range:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\RangeAggregationVisitor
@@ -83,8 +83,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\DateTimeRangeAggregation'
       $searchIndexFieldName: 'value'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ezpublish.search.solr.query.common.aggregation_visitor.field.country_term:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\TermAggregationVisitor
@@ -93,8 +93,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\CountryTermAggregation'
       $searchIndexFieldName: 'idc'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ezpublish.search.solr.query.common.aggregation_visitor.field.float_range:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\RangeAggregationVisitor
@@ -103,8 +103,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\FloatRangeAggregation'
       $searchIndexFieldName: 'value'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ezpublish.search.solr.query.common.aggregation_visitor.field.float_stats:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\StatsAggregationVisitor
@@ -113,8 +113,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\FloatStatsAggregation'
       $searchIndexFieldName: 'value'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ezpublish.search.solr.query.common.aggregation_visitor.field.integer_range:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\RangeAggregationVisitor
@@ -123,8 +123,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\IntegerRangeAggregation'
       $searchIndexFieldName: 'value'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ezpublish.search.solr.query.common.aggregation_visitor.field.integer_stats:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\StatsAggregationVisitor
@@ -133,8 +133,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\IntegerStatsAggregation'
       $searchIndexFieldName: 'value'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ezpublish.search.solr.query.common.aggregation_visitor.field.keyword_term:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\TermAggregationVisitor
@@ -143,8 +143,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\KeywordTermAggregation'
       $searchIndexFieldName: 'value'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ezpublish.search.solr.query.common.aggregation_visitor.field.selection_term:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\TermAggregationVisitor
@@ -153,8 +153,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\SelectionTermAggregation'
       $searchIndexFieldName: 'selected_option_value'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ezpublish.search.solr.query.common.aggregation_visitor.field.time_range:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\RangeAggregationVisitor
@@ -163,8 +163,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field\TimeRangeAggregation'
       $searchIndexFieldName: 'value'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ezpublish.search.solr.query.common.aggregation_visitor.language:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\TermAggregationVisitor
@@ -173,8 +173,8 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\LanguageTermAggregation'
       $searchIndexFieldName: 'content_language_codes_raw_mid'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ezpublish.search.solr.query.common.aggregation_visitor.raw_range:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\RangeAggregationVisitor
@@ -182,8 +182,8 @@ services:
     arguments:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\RawRangeAggregation'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ezpublish.search.solr.query.common.aggregation_visitor.raw_stats:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\StatsAggregationVisitor
@@ -191,8 +191,8 @@ services:
     arguments:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\RawStatsAggregation'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ezpublish.search.solr.query.common.aggregation_visitor.raw_term:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\TermAggregationVisitor
@@ -200,8 +200,8 @@ services:
     arguments:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\RawTermAggregation'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ezpublish.search.solr.query.common.aggregation_visitor.section:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\TermAggregationVisitor
@@ -210,23 +210,23 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\SectionTermAggregation'
       $searchIndexFieldName: 'content_section_id_id'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   Ibexa\Solr\Query\Common\AggregationVisitor\DateMetadataRangeAggregationVisitor:
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   Ibexa\Solr\Query\Common\AggregationVisitor\ObjectStateAggregationVisitor:
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   Ibexa\Solr\Query\Common\AggregationVisitor\UserMetadataTermAggregationVisitor:
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ### Content specific visitors
 
@@ -237,7 +237,7 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\VisibilityTermAggregation'
       $searchIndexFieldName: 'location_visible_b'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
 
   ezpublish.search.solr.query.content.aggregation_visitor.subtree:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\SubtreeTermAggregationVisitor
@@ -245,7 +245,7 @@ services:
       $pathStringFieldName: 'location_path_string_mid'
       $locationIdFieldName: 'location_ancestors_mid'
     tags:
-      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ibexa.search.solr.query.content.aggregation.visitor }
 
   ### Location specific visitors
 
@@ -256,7 +256,7 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\VisibilityTermAggregation'
       $searchIndexFieldName: 'invisible_b'
     tags:
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ezpublish.search.solr.query.location.aggregation_visitor.location_children:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\LocationChildrenTermAggregationVisitor
@@ -265,7 +265,7 @@ services:
       $aggregationClass: 'Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Location\LocationChildrenTermAggregation'
       $searchIndexFieldName: 'parent_id_id'
     tags:
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }
 
   ezpublish.search.solr.query.location.aggregation_visitor.subtree:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\SubtreeTermAggregationVisitor
@@ -273,4 +273,4 @@ services:
       $pathStringFieldName: 'path_string_id'
       $locationIdFieldName: 'location_ancestors_mid'
     tags:
-      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+      - { name: ibexa.search.solr.query.location.aggregation.visitor }

--- a/src/lib/Resources/config/container/solr/criterion_visitors.yml
+++ b/src/lib/Resources/config/container/solr/criterion_visitors.yml
@@ -56,20 +56,20 @@ services:
     ezpublish.search.solr.query.common.criterion_visitor.content_id_in:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.content_id_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.content_type_group_id_in:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.content_type_group_id_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.content_type_id_in:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.content_type_id_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.content_type_identifier_in:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.content_type_identifier_in.class%"
@@ -77,14 +77,14 @@ services:
             - "@ezpublish.spi.persistence.content_type_handler"
             - "@?logger"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.custom_field_in:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.custom_field_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.field_like:
         class: '%ezpublish.search.solr.query.common.criterion_visitor.field_like.class%'
@@ -92,14 +92,14 @@ services:
             - '@ezpublish.search.common.field_name_resolver'
             - '@ezpublish.search.common.field_value_mapper.aggregate'
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.custom_field_range:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.custom_field_range.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.field_in:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.field_in.class%"
@@ -107,8 +107,8 @@ services:
             - "@ezpublish.search.common.field_name_resolver"
             - "@ezpublish.search.common.field_value_mapper.aggregate"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.field_empty:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.field_empty.class%"
@@ -117,8 +117,8 @@ services:
             - "@ezpublish.search.common.field_value_mapper.aggregate"
             - "@ezpublish.search.common.field_name_generator"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.field_range:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.field_range.class%"
@@ -126,8 +126,8 @@ services:
             - "@ezpublish.search.common.field_name_resolver"
             - "@ezpublish.search.common.field_value_mapper.aggregate"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.field_relation:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.field_relation.class%"
@@ -135,32 +135,32 @@ services:
             - "@ezpublish.search.common.field_name_resolver"
             - "@ezpublish.search.common.field_value_mapper.aggregate"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.language_code_in:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.language_code_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.logical_and:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.logical_and.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.logical_not:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.logical_not.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.logical_or:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.logical_or.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.map_location_distance_in:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.map_location_distance_in.class%"
@@ -169,8 +169,8 @@ services:
             - 'ezgmaplocation'
             - 'value_location'
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.map_location_distance_range:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.map_location_distance_range.class%"
@@ -179,93 +179,93 @@ services:
             - 'ezgmaplocation'
             - 'value_location'
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.match_all:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.match_all.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.match_none:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.match_none.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.modified_between:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.modified_between.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.modified_in:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.modified_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.object_state_id_in:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.object_state_id_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     Ibexa\Solr\Query\Common\CriterionVisitor\ObjectStateIdentifierIn:
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.published_between:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.published_between.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.published_in:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.published_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.remote_id_in:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.remote_id_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.section_in:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.section_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     Ibexa\Solr\Query\Common\CriterionVisitor\SectionIdentifierIn:
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     Ibexa\Solr\Query\Common\CriterionVisitor\UserEmailIn:
         tags:
-            - { name: ezpublish.search.solr.query.content.criterion_visitor }
-            - { name: ezpublish.search.solr.query.location.criterion_visitor }
+            - { name: ibexa.search.solr.query.content.criterion.visitor }
+            - { name: ibexa.search.solr.query.location.criterion.visitor }
 
     Ibexa\Solr\Query\Common\CriterionVisitor\UserIdIn:
         tags:
-            - { name: ezpublish.search.solr.query.content.criterion_visitor }
-            - { name: ezpublish.search.solr.query.location.criterion_visitor }
+            - { name: ibexa.search.solr.query.content.criterion.visitor }
+            - { name: ibexa.search.solr.query.location.criterion.visitor }
 
     Ibexa\Solr\Query\Common\CriterionVisitor\UserLoginIn:
         tags:
-            - { name: ezpublish.search.solr.query.content.criterion_visitor }
-            - { name: ezpublish.search.solr.query.location.criterion_visitor }
+            - { name: ibexa.search.solr.query.content.criterion.visitor }
+            - { name: ibexa.search.solr.query.location.criterion.visitor }
 
     ezpublish.search.solr.query.common.criterion_visitor.user_metadata_in:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.user_metadata_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     Ibexa\Solr\Query\Common\CriterionVisitor\Factory\FullTextFactoryAbstract:
         abstract: true
@@ -280,33 +280,33 @@ services:
     ezpublish.search.solr.query.content.criterion_visitor.ancestor:
         class: "%ezpublish.search.solr.query.content.criterion_visitor.ancestor.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.subtree_in:
         class: "%ezpublish.search.solr.query.content.criterion_visitor.subtree_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.location_id_in:
         class: "%ezpublish.search.solr.query.content.criterion_visitor.location_id_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.parent_location_id_in:
         class: "%ezpublish.search.solr.query.content.criterion_visitor.parent_location_id_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.location_remote_id_in:
         class: "%ezpublish.search.solr.query.content.criterion_visitor.location_remote_id_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.full_text:
         class: "%ezpublish.search.solr.query.content.criterion_visitor.full_text.class%"
         factory: ['@Ibexa\Solr\Query\Content\CriterionVisitor\Factory\ContentFullTextFactory', 'createCriterionVisitor']
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
 
     Ibexa\Solr\Query\Content\CriterionVisitor\Factory\ContentFullTextFactory:
         parent: Ibexa\Solr\Query\Common\CriterionVisitor\Factory\FullTextFactoryAbstract
@@ -314,74 +314,74 @@ services:
     ezpublish.search.solr.query.content.criterion_visitor.visibility:
         class: "%ezpublish.search.solr.query.content.criterion_visitor.visibility.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
 
     # Location search
     ezpublish.search.solr.query.location.criterion_visitor.ancestor:
         class: "%ezpublish.search.solr.query.location.criterion_visitor.ancestor.class%"
         tags:
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.subtree_in:
         class: "%ezpublish.search.solr.query.location.criterion_visitor.subtree_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.location_id_in:
         class: "%ezpublish.search.solr.query.location.criterion_visitor.location_id_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.parent_location_id_in:
         class: "%ezpublish.search.solr.query.location.criterion_visitor.parent_location_id_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.location_remote_id_in:
         class: "%ezpublish.search.solr.query.location.criterion_visitor.location_remote_id_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.visibility:
         class: "%ezpublish.search.solr.query.location.criterion_visitor.visibility.class%"
         tags:
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.depth_in:
         class: "%ezpublish.search.solr.query.location.criterion_visitor.depth_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.depth_between:
         class: "%ezpublish.search.solr.query.location.criterion_visitor.depth_between.class%"
         tags:
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.is_main_location:
         class: "%ezpublish.search.solr.query.location.criterion_visitor.is_main_location.class%"
         tags:
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.priority_in:
         class: "%ezpublish.search.solr.query.location.criterion_visitor.priority_in.class%"
         tags:
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.priority_between:
         class: "%ezpublish.search.solr.query.location.criterion_visitor.priority_between.class%"
         tags:
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.full_text:
         class: "%ezpublish.search.solr.query.location.criterion_visitor.full_text.class%"
         factory: ['@Ibexa\Solr\Query\Location\CriterionVisitor\Factory\LocationFullTextFactory', 'createCriterionVisitor']
         tags:
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}
 
     Ibexa\Solr\Query\Location\CriterionVisitor\Factory\LocationFullTextFactory:
         parent: Ibexa\Solr\Query\Common\CriterionVisitor\Factory\FullTextFactoryAbstract
 
     Ibexa\Solr\Query\Common\CriterionVisitor\CompositeCriterion:
         tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+            - {name: ibexa.search.solr.query.content.criterion.visitor}
+            - {name: ibexa.search.solr.query.location.criterion.visitor}

--- a/src/lib/Resources/config/container/solr/facet_builder_visitors.yml
+++ b/src/lib/Resources/config/container/solr/facet_builder_visitors.yml
@@ -7,17 +7,17 @@ services:
     ezpublish.search.solr.query.common.facet_builder_visitor.content_type:
         class: "%ezpublish.search.solr.query.common.facet_builder_visitor.content_type.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.facet_builder_visitor}
-            - {name: ezpublish.search.solr.query.location.facet_builder_visitor}
+            - {name: ibexa.search.solr.query.content.facet_builder.visitor}
+            - {name: ibexa.search.solr.query.location.facet_builder.visitor}
 
     ezpublish.search.solr.query.common.facet_builder_visitor.section:
         class: "%ezpublish.search.solr.query.common.facet_builder_visitor.section.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.facet_builder_visitor}
-            - {name: ezpublish.search.solr.query.location.facet_builder_visitor}
+            - {name: ibexa.search.solr.query.content.facet_builder.visitor}
+            - {name: ibexa.search.solr.query.location.facet_builder.visitor}
 
     ezpublish.search.solr.query.common.facet_builder_visitor.user:
         class: "%ezpublish.search.solr.query.common.facet_builder_visitor.user.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.facet_builder_visitor}
-            - {name: ezpublish.search.solr.query.location.facet_builder_visitor}
+            - {name: ibexa.search.solr.query.content.facet_builder.visitor}
+            - {name: ibexa.search.solr.query.location.facet_builder.visitor}

--- a/src/lib/Resources/config/container/solr/field_mappers.yml
+++ b/src/lib/Resources/config/container/solr/field_mappers.yml
@@ -17,7 +17,7 @@ services:
             - '@ezpublish.spi.persistence.object_state_handler'
             - '@ezpublish.spi.persistence.section_handler'
         tags:
-            - {name: ezpublish.search.solr.field_mapper.block}
+            - {name: ibexa.search.solr.field.mapper.block}
 
     ezpublish.search.solr.field_mapper.block_translation.block_documents_content_fields:
         class: '%ezpublish.search.solr.field_mapper.block_translation.block_documents_content_fields.class%'
@@ -27,12 +27,12 @@ services:
             - '@ezpublish.search.common.field_name_generator'
             - '@ezpublish.search.solr.field_mapper.boost_factor_provider'
         tags:
-            - {name: ezpublish.search.solr.field_mapper.block_translation}
+            - {name: ibexa.search.solr.field.mapper.block_translation}
 
     ezpublish.search.solr.field_mapper.block_translation.block_documents_meta_fields:
         class: '%ezpublish.search.solr.field_mapper.block_translation.block_documents_meta_fields.class%'
         tags:
-            - {name: ezpublish.search.solr.field_mapper.block_translation}
+            - {name: ibexa.search.solr.field.mapper.block_translation}
 
     ezpublish.search.solr.field_mapper.content_translation.content_document_translated_content_name_field:
         class: '%ezpublish.search.solr.field_mapper.content_translation.content_document_translated_content_name_field.class%'
@@ -40,23 +40,23 @@ services:
             - '@ezpublish.spi.persistence.content_type_handler'
             - '@ezpublish.search.solr.field_mapper.boost_factor_provider'
         tags:
-            - {name: ezpublish.search.solr.field_mapper.block_translation}
+            - {name: ibexa.search.solr.field.mapper.block_translation}
 
     ezpublish.search.solr.field_mapper.content.content_document_base_fields:
         class: '%ezpublish.search.solr.field_mapper.content.content_document_base_fields.class%'
         tags:
-            - {name: ezpublish.search.solr.field_mapper.content}
+            - {name: ibexa.search.solr.field.mapper.content}
 
     Ibexa\Solr\FieldMapper\ContentFieldMapper\UserDocumentFields:
         tags:
-            - { name: ezpublish.search.solr.field_mapper.content }
+            - { name: ibexa.search.solr.field.mapper.content }
 
     ezpublish.search.solr.field_mapper.content.content_document_location_fields:
         class: '%ezpublish.search.solr.field_mapper.content.content_document_location_fields.class%'
         arguments:
             - '@ezpublish.spi.persistence.location_handler'
         tags:
-            - {name: ezpublish.search.solr.field_mapper.content}
+            - {name: ibexa.search.solr.field.mapper.content}
 
     ezpublish.search.solr.field_mapper.content_translation.content_document_fulltext_fields:
         class: '%ezpublish.search.solr.field_mapper.content_translation.content_document_fulltext_fields.class%'
@@ -68,14 +68,14 @@ services:
             - '@ezpublish.search.solr.field_mapper.boost_factor_provider'
             - '@ezpublish.search.solr.field_mapper.indexing_depth_provider'
         tags:
-            - {name: ezpublish.search.solr.field_mapper.content_translation}
+            - {name: ibexa.search.solr.field.mapper.content_translation}
 
     ezpublish.search.solr.field_mapper.location.location_document_base_fields:
         class: '%ezpublish.search.solr.field_mapper.location.location_document_base_fields.class%'
         arguments:
             - '@ezpublish.spi.persistence.content_handler'
         tags:
-            - {name: ezpublish.search.solr.field_mapper.location}
+            - {name: ibexa.search.solr.field.mapper.location}
 
     ezpublish.search.solr.field_mapper.content_translation.content_document_empty_fields:
         class: Ibexa\Solr\FieldMapper\ContentTranslationFieldMapper\ContentDocumentEmptyFields
@@ -84,4 +84,4 @@ services:
             - '@ezpublish.search.common.field_name_generator'
             - '@ezpublish.persistence.field_type_registry'
         tags:
-            - {name: ezpublish.search.solr.field_mapper.block_translation}
+            - {name: ibexa.search.solr.field.mapper.block_translation}

--- a/src/lib/Resources/config/container/solr/services.yml
+++ b/src/lib/Resources/config/container/solr/services.yml
@@ -19,57 +19,57 @@ services:
         class: "%ezpublish.search.solr.gateway.client.http.stream.class%"
         arguments: ["@?logger"]
 
-    # Note: services tagged with 'ezpublish.search.solr.query.content.criterion_visitor'
+    # Note: services tagged with 'ibexa.search.solr.query.content.criterion.visitor'
     # are registered to this one using compilation pass
     ezpublish.search.solr.query.content.criterion_visitor.aggregate:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.aggregate.class%"
 
-    # Note: services tagged with 'ezpublish.search.solr.query.content.sort_clause_visitor'
+    # Note: services tagged with 'ibexa.search.solr.query.content.sort_clause.visitor'
     # are registered to this one using compilation pass
     ezpublish.search.solr.query.content.sort_clause_visitor.aggregate:
         class: "%ezpublish.search.solr.query.common.sort_clause_visitor.aggregate.class%"
 
-    # Note: services tagged with 'ezpublish.search.solr.query.content.facet_builder_visitor'
+    # Note: services tagged with 'ibexa.search.solr.query.content.facet_builder.visitor'
     # are registered to this one using compilation pass
     ezpublish.search.solr.query.content.facet_builder_visitor.aggregate:
         class: "%ezpublish.search.solr.query.common.facet_builder_visitor.aggregate.class%"
 
-    # Note: services tagged with 'ezpublish.search.solr.query.location.criterion_visitor'
+    # Note: services tagged with 'ibexa.search.solr.query.location.criterion.visitor'
     # are registered to this one using compilation pass
     ezpublish.search.solr.query.location.criterion_visitor.aggregate:
         class: "%ezpublish.search.solr.query.common.criterion_visitor.aggregate.class%"
 
-    # Note: services tagged with 'ezpublish.search.solr.query.location.sort_clause_visitor'
+    # Note: services tagged with 'ibexa.search.solr.query.location.sort_clause.visitor'
     # are registered to this one using compilation pass
     ezpublish.search.solr.query.location.sort_clause_visitor.aggregate:
         class: "%ezpublish.search.solr.query.common.sort_clause_visitor.aggregate.class%"
 
-    # Note: services tagged with 'ezpublish.search.solr.query.location.facet_builder_visitor'
+    # Note: services tagged with 'ibexa.search.solr.query.location.facet_builder.visitor'
     # are registered to this one using compilation pass
     ezpublish.search.solr.query.location.facet_builder_visitor.aggregate:
         class: "%ezpublish.search.solr.query.common.facet_builder_visitor.aggregate.class%"
 
-    # Note: services tagged with 'ezpublish.search.solr.field_mapper.block'
+    # Note: services tagged with 'ibexa.search.solr.field.mapper.block'
     # are registered to this one using compilation pass
     ezpublish.search.solr.field_mapper.block:
         class: "%ezpublish.search.solr.field_mapper.block.class%"
 
-    # Note: services tagged with 'ezpublish.search.solr.field_mapper.block_translation'
+    # Note: services tagged with 'ibexa.search.solr.field.mapper.block_translation'
     # are registered to this one using compilation pass
     ezpublish.search.solr.field_mapper.block_translation:
         class: "%ezpublish.search.solr.field_mapper.block_translation.class%"
 
-    # Note: services tagged with 'ezpublish.search.solr.field_mapper.content'
+    # Note: services tagged with 'ibexa.search.solr.field.mapper.content'
     # are registered to this one using compilation pass
     ezpublish.search.solr.field_mapper.content:
         class: "%ezpublish.search.solr.field_mapper.content.class%"
 
-    # Note: services tagged with 'ezpublish.search.solr.field_mapper.content_translation'
+    # Note: services tagged with 'ibexa.search.solr.field.mapper.content_translation'
     # are registered to this one using compilation pass
     ezpublish.search.solr.field_mapper.content_translation:
         class: "%ezpublish.search.solr.field_mapper.content_translation.class%"
 
-    # Note: services tagged with 'ezpublish.search.solr.field_mapper.location'
+    # Note: services tagged with 'ibexa.search.solr.field.mapper.location'
     # are registered to this one using compilation pass
     ezpublish.search.solr.field_mapper.location:
         class: "%ezpublish.search.solr.field_mapper.location.class%"

--- a/src/lib/Resources/config/container/solr/sort_clause_visitors.yml
+++ b/src/lib/Resources/config/container/solr/sort_clause_visitors.yml
@@ -22,51 +22,51 @@ services:
     ezpublish.search.solr.query.common.sort_clause_visitor.content_id:
         class: "%ezpublish.search.solr.query.common.sort_clause_visitor.content_id.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
-            - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
+            - {name: ibexa.search.solr.query.content.sort_clause.visitor}
+            - {name: ibexa.search.solr.query.location.sort_clause.visitor}
 
     ezpublish.search.solr.query.common.sort_clause_visitor.content_name:
         class: "%ezpublish.search.solr.query.common.sort_clause_visitor.content_name.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
-            - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
+            - {name: ibexa.search.solr.query.content.sort_clause.visitor}
+            - {name: ibexa.search.solr.query.location.sort_clause.visitor}
 
     Ibexa\Solr\Query\Common\SortClauseVisitor\ContentTranslatedName:
         tags:
-            - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
-            - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
+            - {name: ibexa.search.solr.query.content.sort_clause.visitor}
+            - {name: ibexa.search.solr.query.location.sort_clause.visitor}
 
     ezpublish.search.solr.query.common.sort_clause_visitor.field:
         class: "%ezpublish.search.solr.query.common.sort_clause_visitor.field.class%"
         arguments:
             - "@ezpublish.search.common.field_name_resolver"
         tags:
-            - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
-            - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
+            - {name: ibexa.search.solr.query.content.sort_clause.visitor}
+            - {name: ibexa.search.solr.query.location.sort_clause.visitor}
 
     ezpublish.search.solr.query.common.sort_clause_visitor.section_identifier:
         class: "%ezpublish.search.solr.query.common.sort_clause_visitor.section_identifier.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
-            - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
+            - {name: ibexa.search.solr.query.content.sort_clause.visitor}
+            - {name: ibexa.search.solr.query.location.sort_clause.visitor}
 
     ezpublish.search.solr.query.common.sort_clause_visitor.section_name:
         class: "%ezpublish.search.solr.query.common.sort_clause_visitor.section_name.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
-            - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
+            - {name: ibexa.search.solr.query.content.sort_clause.visitor}
+            - {name: ibexa.search.solr.query.location.sort_clause.visitor}
 
     ezpublish.search.solr.query.common.sort_clause_visitor.date_published:
         class: "%ezpublish.search.solr.query.common.sort_clause_visitor.date_published.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
-            - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
+            - {name: ibexa.search.solr.query.content.sort_clause.visitor}
+            - {name: ibexa.search.solr.query.location.sort_clause.visitor}
 
     ezpublish.search.solr.query.common.sort_clause_visitor.date_modified:
         class: "%ezpublish.search.solr.query.common.sort_clause_visitor.date_modified.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
-            - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
+            - {name: ibexa.search.solr.query.content.sort_clause.visitor}
+            - {name: ibexa.search.solr.query.location.sort_clause.visitor}
 
     ezpublish.search.solr.query.common.sort_clause_visitor.map_location_distance:
         class: "%ezpublish.search.solr.query.common.sort_clause_visitor.map_location_distance.class%"
@@ -74,52 +74,52 @@ services:
             - "@ezpublish.search.common.field_name_resolver"
             - 'value_location'
         tags:
-            - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
-            - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
+            - {name: ibexa.search.solr.query.content.sort_clause.visitor}
+            - {name: ibexa.search.solr.query.location.sort_clause.visitor}
 
     ezpublish.search.solr.query.common.sort_clause_visitor.random:
         class: "%ezpublish.search.solr.query.common.sort_clause_visitor.random.class%"
         tags:
-            - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
-            - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
+            - {name: ibexa.search.solr.query.content.sort_clause.visitor}
+            - {name: ibexa.search.solr.query.location.sort_clause.visitor}
 
     Ibexa\Solr\Query\Common\SortClauseVisitor\CustomField:
         tags:
-            - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
-            - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
+            - {name: ibexa.search.solr.query.content.sort_clause.visitor}
+            - {name: ibexa.search.solr.query.location.sort_clause.visitor}
 
     Ibexa\Solr\Query\Common\SortClauseVisitor\Score:
         tags:
-            - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
-            - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
+            - {name: ibexa.search.solr.query.content.sort_clause.visitor}
+            - {name: ibexa.search.solr.query.location.sort_clause.visitor}
 
     # Location search
     ezpublish.search.solr.query.location.sort_clause_visitor.depth:
         class: "%ezpublish.search.solr.query.location.sort_clause_visitor.depth.class%"
         tags:
-            - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
+            - {name: ibexa.search.solr.query.location.sort_clause.visitor}
 
     ezpublish.search.solr.query.location.sort_clause_visitor.id:
         class: "%ezpublish.search.solr.query.location.sort_clause_visitor.id.class%"
         tags:
-            - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
+            - {name: ibexa.search.solr.query.location.sort_clause.visitor}
 
     ezpublish.search.solr.query.location.sort_clause_visitor.is_main_location:
         class: "%ezpublish.search.solr.query.location.sort_clause_visitor.is_main_location.class%"
         tags:
-            - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
+            - {name: ibexa.search.solr.query.location.sort_clause.visitor}
 
     ezpublish.search.solr.query.location.sort_clause_visitor.path:
         class: "%ezpublish.search.solr.query.location.sort_clause_visitor.path.class%"
         tags:
-            - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
+            - {name: ibexa.search.solr.query.location.sort_clause.visitor}
 
     ezpublish.search.solr.query.location.sort_clause_visitor.priority:
         class: "%ezpublish.search.solr.query.location.sort_clause_visitor.priority.class%"
         tags:
-            - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
+            - {name: ibexa.search.solr.query.location.sort_clause.visitor}
 
     ezpublish.search.solr.query.location.sort_clause_visitor.visibility:
         class: "%ezpublish.search.solr.query.location.sort_clause_visitor.visibility.class%"
         tags:
-            - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
+            - {name: ibexa.search.solr.query.location.sort_clause.visitor}

--- a/tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
+++ b/tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
@@ -136,7 +136,7 @@ class IbexaSolrExtensionExtensionTest extends AbstractExtensionTestCase
 
         $this->assertContainerBuilderHasServiceDefinitionWithTag(
             "ez_search_engine_solr.endpoints.{$endpointName}",
-            'ezpublish.search.solr.endpoint',
+            'ibexa.search.solr.endpoint',
             ['alias' => $endpointName]
         );
         $this->assertContainerBuilderHasServiceDefinitionWithArgument(

--- a/tests/lib/Container/Compiler/AggregateCriterionVisitorPassTest.php
+++ b/tests/lib/Container/Compiler/AggregateCriterionVisitorPassTest.php
@@ -38,7 +38,7 @@ class AggregateCriterionVisitorPassTest extends AbstractCompilerPassTestCase
     {
         $serviceId = 'service_id';
         $def = new Definition();
-        $def->addTag('ezpublish.search.solr.query.content.criterion_visitor');
+        $def->addTag('ibexa.search.solr.query.content.criterion.visitor');
         $this->setDefinition($serviceId, $def);
 
         $this->compile();

--- a/tests/lib/Container/Compiler/AggregateFacetBuilderVisitorPassTest.php
+++ b/tests/lib/Container/Compiler/AggregateFacetBuilderVisitorPassTest.php
@@ -42,12 +42,12 @@ class AggregateFacetBuilderVisitorPassTest extends AbstractCompilerPassTestCase
     {
         $serviceId = 'service_id';
         $def = new Definition();
-        $def->addTag('ezpublish.search.solr.query.content.facet_builder_visitor');
+        $def->addTag('ibexa.search.solr.query.content.facet_builder.visitor');
         $this->setDefinition($serviceId, $def);
 
         $serviceId2 = 'service_id2';
         $def = new Definition();
-        $def->addTag('ezpublish.search.solr.query.location.facet_builder_visitor');
+        $def->addTag('ibexa.search.solr.query.location.facet_builder.visitor');
         $this->setDefinition($serviceId2, $def);
 
         $this->compile();

--- a/tests/lib/Container/Compiler/AggregateSortClauseVisitorPassTest.php
+++ b/tests/lib/Container/Compiler/AggregateSortClauseVisitorPassTest.php
@@ -38,7 +38,7 @@ class AggregateSortClauseVisitorPassTest extends AbstractCompilerPassTestCase
     {
         $serviceId = 'service_id';
         $def = new Definition();
-        $def->addTag('ezpublish.search.solr.query.content.sort_clause_visitor');
+        $def->addTag('ibexa.search.solr.query.content.sort_clause.visitor');
         $this->setDefinition($serviceId, $def);
 
         $this->compile();

--- a/tests/lib/Resources/config/cloud.yml
+++ b/tests/lib/Resources/config/cloud.yml
@@ -38,7 +38,7 @@ services:
                 path: /solr
                 core: core0
         tags:
-            - {name: ezpublish.search.solr.endpoint, alias: eng}
+            - {name: ibexa.search.solr.endpoint, alias: eng}
 
     ezpublish.search.solr.endpoint.ger:
         class: "%ezpublish.solr.endpoint.class%"
@@ -50,7 +50,7 @@ services:
                 path: /solr
                 core: core1
         tags:
-            - {name: ezpublish.search.solr.endpoint, alias: ger}
+            - {name: ibexa.search.solr.endpoint, alias: ger}
 
     ezpublish.search.solr.endpoint.default:
         class: "%ezpublish.solr.endpoint.class%"
@@ -62,7 +62,7 @@ services:
                 path: /solr
                 core: core2
         tags:
-            - {name: ezpublish.search.solr.endpoint, alias: default}
+            - {name: ibexa.search.solr.endpoint, alias: default}
 
     ezpublish.search.solr.endpoint.main:
         class: "%ezpublish.solr.endpoint.class%"
@@ -74,7 +74,7 @@ services:
                 path: /solr
                 core: core3
         tags:
-            - {name: ezpublish.search.solr.endpoint, alias: main}
+            - {name: ibexa.search.solr.endpoint, alias: main}
 
     ezpublish.search.solr.gateway.distribution_strategy.cloud:
         class: Ibexa\Solr\Gateway\DistributionStrategy\CloudDistributionStrategy

--- a/tests/lib/Resources/config/multicore_dedicated.yml
+++ b/tests/lib/Resources/config/multicore_dedicated.yml
@@ -37,7 +37,7 @@ services:
                 path: /solr
                 core: core0
         tags:
-            - {name: ezpublish.search.solr.endpoint, alias: endpoint0}
+            - {name: ibexa.search.solr.endpoint, alias: endpoint0}
 
     ezpublish.search.solr.endpoint.endpoint1:
         class: "%ezpublish.solr.endpoint.class%"
@@ -49,7 +49,7 @@ services:
                 path: /solr
                 core: core1
         tags:
-            - {name: ezpublish.search.solr.endpoint, alias: endpoint1}
+            - {name: ibexa.search.solr.endpoint, alias: endpoint1}
 
     ezpublish.search.solr.endpoint.endpoint2:
         class: "%ezpublish.solr.endpoint.class%"
@@ -61,7 +61,7 @@ services:
                 path: /solr
                 core: core2
         tags:
-            - {name: ezpublish.search.solr.endpoint, alias: endpoint2}
+            - {name: ibexa.search.solr.endpoint, alias: endpoint2}
 
     ezpublish.search.solr.endpoint.endpoint3:
         class: "%ezpublish.solr.endpoint.class%"
@@ -73,7 +73,7 @@ services:
                 path: /solr
                 core: core3
         tags:
-            - {name: ezpublish.search.solr.endpoint, alias: endpoint3}
+            - {name: ibexa.search.solr.endpoint, alias: endpoint3}
 
     ezpublish.search.solr.endpoint.endpoint4:
         class: "%ezpublish.solr.endpoint.class%"
@@ -85,7 +85,7 @@ services:
                 path: /solr
                 core: core4
         tags:
-            - {name: ezpublish.search.solr.endpoint, alias: endpoint4}
+            - {name: ibexa.search.solr.endpoint, alias: endpoint4}
 
     ezpublish.search.solr.endpoint.endpoint5:
         class: "%ezpublish.solr.endpoint.class%"
@@ -97,4 +97,4 @@ services:
                 path: /solr
                 core: core5
         tags:
-            - {name: ezpublish.search.solr.endpoint, alias: endpoint5}
+            - {name: ibexa.search.solr.endpoint, alias: endpoint5}

--- a/tests/lib/Resources/config/multicore_shared.yml
+++ b/tests/lib/Resources/config/multicore_shared.yml
@@ -32,7 +32,7 @@ services:
                 path: /solr
                 core: core0
         tags:
-            - {name: ezpublish.search.solr.endpoint, alias: endpoint0}
+            - {name: ibexa.search.solr.endpoint, alias: endpoint0}
 
     ezpublish.search.solr.endpoint.endpoint1:
         class: "%ezpublish.solr.endpoint.class%"
@@ -44,7 +44,7 @@ services:
                 path: /solr
                 core: core1
         tags:
-            - {name: ezpublish.search.solr.endpoint, alias: endpoint1}
+            - {name: ibexa.search.solr.endpoint, alias: endpoint1}
 
     ezpublish.search.solr.endpoint.endpoint2:
         class: "%ezpublish.solr.endpoint.class%"
@@ -56,7 +56,7 @@ services:
                 path: /solr
                 core: core2
         tags:
-            - {name: ezpublish.search.solr.endpoint, alias: endpoint2}
+            - {name: ibexa.search.solr.endpoint, alias: endpoint2}
 
     ezpublish.search.solr.endpoint.endpoint3:
         class: "%ezpublish.solr.endpoint.class%"
@@ -68,4 +68,4 @@ services:
                 path: /solr
                 core: core3
         tags:
-            - {name: ezpublish.search.solr.endpoint, alias: endpoint3}
+            - {name: ibexa.search.solr.endpoint, alias: endpoint3}

--- a/tests/lib/Resources/config/single_core.yml
+++ b/tests/lib/Resources/config/single_core.yml
@@ -31,4 +31,4 @@ services:
                 path: /solr
                 core: collection1
         tags:
-            - {name: ezpublish.search.solr.endpoint, alias: endpoint0}
+            - {name: ibexa.search.solr.endpoint, alias: endpoint0}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1694](https://issues.ibexa.co/browse/IBX-1694)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#12

In this Pull Request we rename Ibexa's dependency injection container service tags according to the map provided by ibexa/compatibility-layer#12 as a part of the rebranding process. Backward compatibility for old service tags is provided by ibexa/compatibility-layer#12.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Asked for a review
