### PR TITLE
IBX-1694: Fixed translation mappers service tag name

### DIFF
--- a/bin/.travis/init_solr.sh
+++ b/bin/.travis/init_solr.sh
@@ -45,7 +45,7 @@ fi
 download() {
     case ${SOLR_VERSION} in
         # PS!!: Append versions and don't remove old ones (except in major versions), used in integration tests from other packages!
-        7.7.* | 8.[5-11].* )
+        7.7.* | 8.* )
             url="http://archive.apache.org/dist/lucene/solr/${SOLR_VERSION}/solr-${SOLR_VERSION}.tgz"
             ;;
         *)

--- a/src/lib/Container/Compiler/FieldMapperPass/BlockFieldMapperPass.php
+++ b/src/lib/Container/Compiler/FieldMapperPass/BlockFieldMapperPass.php
@@ -13,8 +13,8 @@ use Ibexa\Solr\Container\Compiler\BaseFieldMapperPass;
  */
 class BlockFieldMapperPass extends BaseFieldMapperPass
 {
-    public const AGGREGATE_MAPPER_SERVICE_ID = 'ibexa.search.solr.field.mapper.block';
-    public const AGGREGATE_MAPPER_SERVICE_TAG = self::AGGREGATE_MAPPER_SERVICE_ID;
+    public const AGGREGATE_MAPPER_SERVICE_ID = 'ezpublish.search.solr.field_mapper.block';
+    public const AGGREGATE_MAPPER_SERVICE_TAG = 'ibexa.search.solr.field.mapper.block';
 }
 
 class_alias(BlockFieldMapperPass::class, 'EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\FieldMapperPass\BlockFieldMapperPass');

--- a/src/lib/Container/Compiler/FieldMapperPass/BlockTranslationFieldMapperPass.php
+++ b/src/lib/Container/Compiler/FieldMapperPass/BlockTranslationFieldMapperPass.php
@@ -14,8 +14,8 @@ use Ibexa\Solr\Container\Compiler\BaseFieldMapperPass;
  */
 class BlockTranslationFieldMapperPass extends BaseFieldMapperPass
 {
-    public const AGGREGATE_MAPPER_SERVICE_ID = 'ibexa.search.solr.field.mapper.block.translation';
-    public const AGGREGATE_MAPPER_SERVICE_TAG = self::AGGREGATE_MAPPER_SERVICE_ID;
+    public const AGGREGATE_MAPPER_SERVICE_ID = 'ezpublish.search.solr.field_mapper.block_translation';
+    public const AGGREGATE_MAPPER_SERVICE_TAG = 'ibexa.search.solr.field.mapper.block.translation';
 }
 
 class_alias(BlockTranslationFieldMapperPass::class, 'EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\FieldMapperPass\BlockTranslationFieldMapperPass');

--- a/src/lib/Container/Compiler/FieldMapperPass/ContentFieldMapperPass.php
+++ b/src/lib/Container/Compiler/FieldMapperPass/ContentFieldMapperPass.php
@@ -13,8 +13,8 @@ use Ibexa\Solr\Container\Compiler\BaseFieldMapperPass;
  */
 class ContentFieldMapperPass extends BaseFieldMapperPass
 {
-    public const AGGREGATE_MAPPER_SERVICE_ID = 'ibexa.search.solr.field.mapper.content';
-    public const AGGREGATE_MAPPER_SERVICE_TAG = self::AGGREGATE_MAPPER_SERVICE_ID;
+    public const AGGREGATE_MAPPER_SERVICE_ID = 'ezpublish.search.solr.field_mapper.content';
+    public const AGGREGATE_MAPPER_SERVICE_TAG = 'ibexa.search.solr.field.mapper.content';
 }
 
 class_alias(ContentFieldMapperPass::class, 'EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\FieldMapperPass\ContentFieldMapperPass');

--- a/src/lib/Container/Compiler/FieldMapperPass/ContentTranslationFieldMapperPass.php
+++ b/src/lib/Container/Compiler/FieldMapperPass/ContentTranslationFieldMapperPass.php
@@ -14,8 +14,8 @@ use Ibexa\Solr\Container\Compiler\BaseFieldMapperPass;
  */
 class ContentTranslationFieldMapperPass extends BaseFieldMapperPass
 {
-    public const AGGREGATE_MAPPER_SERVICE_ID = 'ibexa.search.solr.field.mapper.content.translation';
-    public const AGGREGATE_MAPPER_SERVICE_TAG = self::AGGREGATE_MAPPER_SERVICE_ID;
+    public const AGGREGATE_MAPPER_SERVICE_ID = 'ezpublish.search.solr.field_mapper.content_translation';
+    public const AGGREGATE_MAPPER_SERVICE_TAG = 'ibexa.search.solr.field.mapper.content.translation';
 }
 
 class_alias(ContentTranslationFieldMapperPass::class, 'EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\FieldMapperPass\ContentTranslationFieldMapperPass');

--- a/src/lib/Container/Compiler/FieldMapperPass/LocationFieldMapperPass.php
+++ b/src/lib/Container/Compiler/FieldMapperPass/LocationFieldMapperPass.php
@@ -13,8 +13,8 @@ use Ibexa\Solr\Container\Compiler\BaseFieldMapperPass;
  */
 class LocationFieldMapperPass extends BaseFieldMapperPass
 {
-    public const AGGREGATE_MAPPER_SERVICE_ID = 'ibexa.search.solr.field.mapper.location';
-    public const AGGREGATE_MAPPER_SERVICE_TAG = self::AGGREGATE_MAPPER_SERVICE_ID;
+    public const AGGREGATE_MAPPER_SERVICE_ID = 'ezpublish.search.solr.field_mapper.location';
+    public const AGGREGATE_MAPPER_SERVICE_TAG = 'ibexa.search.solr.field.mapper.location';
 }
 
 class_alias(LocationFieldMapperPass::class, 'EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\FieldMapperPass\LocationFieldMapperPass');

--- a/src/lib/Resources/config/container/solr/field_mappers.yml
+++ b/src/lib/Resources/config/container/solr/field_mappers.yml
@@ -27,12 +27,12 @@ services:
             - '@ezpublish.search.common.field_name_generator'
             - '@ezpublish.search.solr.field_mapper.boost_factor_provider'
         tags:
-            - {name: ibexa.search.solr.field.mapper.block_translation}
+            - {name: ibexa.search.solr.field.mapper.block.translation}
 
     ezpublish.search.solr.field_mapper.block_translation.block_documents_meta_fields:
         class: '%ezpublish.search.solr.field_mapper.block_translation.block_documents_meta_fields.class%'
         tags:
-            - {name: ibexa.search.solr.field.mapper.block_translation}
+            - {name: ibexa.search.solr.field.mapper.block.translation}
 
     ezpublish.search.solr.field_mapper.content_translation.content_document_translated_content_name_field:
         class: '%ezpublish.search.solr.field_mapper.content_translation.content_document_translated_content_name_field.class%'
@@ -40,7 +40,7 @@ services:
             - '@ezpublish.spi.persistence.content_type_handler'
             - '@ezpublish.search.solr.field_mapper.boost_factor_provider'
         tags:
-            - {name: ibexa.search.solr.field.mapper.block_translation}
+            - {name: ibexa.search.solr.field.mapper.block.translation}
 
     ezpublish.search.solr.field_mapper.content.content_document_base_fields:
         class: '%ezpublish.search.solr.field_mapper.content.content_document_base_fields.class%'
@@ -68,7 +68,7 @@ services:
             - '@ezpublish.search.solr.field_mapper.boost_factor_provider'
             - '@ezpublish.search.solr.field_mapper.indexing_depth_provider'
         tags:
-            - {name: ibexa.search.solr.field.mapper.content_translation}
+            - {name: ibexa.search.solr.field.mapper.content.translation}
 
     ezpublish.search.solr.field_mapper.location.location_document_base_fields:
         class: '%ezpublish.search.solr.field_mapper.location.location_document_base_fields.class%'
@@ -84,4 +84,4 @@ services:
             - '@ezpublish.search.common.field_name_generator'
             - '@ezpublish.persistence.field_type_registry'
         tags:
-            - {name: ibexa.search.solr.field.mapper.block_translation}
+            - {name: ibexa.search.solr.field.mapper.block.translation}

--- a/src/lib/Resources/config/container/solr/services.yml
+++ b/src/lib/Resources/config/container/solr/services.yml
@@ -64,7 +64,7 @@ services:
     ezpublish.search.solr.field_mapper.content:
         class: "%ezpublish.search.solr.field_mapper.content.class%"
 
-    # Note: services tagged with 'ibexa.search.solr.field.mapper.content_translation'
+    # Note: services tagged with 'ibexa.search.solr.field.mapper.content.translation'
     # are registered to this one using compilation pass
     ezpublish.search.solr.field_mapper.content_translation:
         class: "%ezpublish.search.solr.field_mapper.content_translation.class%"


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | Follow-up to [IBX-1694](https://issues.ibexa.co/browse/IBX-1694)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

#12 introduced incorrect tag name for `ibexa.search.solr.field.mapper.block.translation` and `ibexa.search.solr.field.mapper.content.translation` service tag names.

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly
- [ ] Asked for a review