### PR TITLE
IBX-2451: migrate service definition and tag name

### DIFF
--- a/src/lib/Container/Compiler/AggregateFacetBuilderVisitorPass.php
+++ b/src/lib/Container/Compiler/AggregateFacetBuilderVisitorPass.php
@@ -23,15 +23,15 @@ class AggregateFacetBuilderVisitorPass implements CompilerPassInterface
 
     private function processVisitors(ContainerBuilder $container, $name = 'content')
     {
-        if (!$container->hasDefinition("ezpublish.search.solr.query.${name}.facet_builder_visitor.aggregate")) {
+        if (!$container->hasDefinition("ibexa.solr.query.${name}.facet_builder_visitor.aggregate")) {
             return;
         }
 
         $aggregateFacetBuilderVisitorDefinition = $container->getDefinition(
-            "ezpublish.search.solr.query.${name}.facet_builder_visitor.aggregate"
+            "ibexa.solr.query.${name}.facet_builder_visitor.aggregate"
         );
 
-        foreach ($container->findTaggedServiceIds("ezpublish.search.solr.query.${name}.facet_builder_visitor") as $id => $attributes) {
+        foreach ($container->findTaggedServiceIds("ibexa.search.solr.query.${name}.facet_builder_visitor") as $id => $attributes) {
             $aggregateFacetBuilderVisitorDefinition->addMethodCall(
                 'addVisitor',
                 [


### PR DESCRIPTION
Issue link: https://issues.ibexa.co/browse/IBX-2451

`AggregateSortClauseVisitorPass` compiler pass has not been fully migrated.