### PR TITLE
IBX-1439: Dropped league/flysystem-memory dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "symfony/http-client": "^5.4"
     },
     "require-dev": {
-        "league/flysystem-memory": "^1.0",
         "symfony/proxy-manager-bridge": "^5.4",
         "ibexa/doctrine-schema": "~4.4.0@dev",
         "phpunit/phpunit": "^8.2",


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1439](https://issues.ibexa.co/browse/IBX-1439)
| **Requires**                            | ibexa/core#171
| **Type**                                   | feature
| **Target Ibexa version** | `v4.4`
| **BC breaks**                          | not for this package

~This PR updates codebase to use Flysystem v2. Bumped `league/flysystem-memory` to v2.~
This PR drops `league/flysystem-memory` dependency required now by `ibexa/core` (ibexa/core#171).

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review
