### PR TITLE
IBX-5061: Allowed DateMetadata `published` target

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,5 +69,10 @@
         "branch-alias": {
             "dev-main": "4.3.x-dev"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "*": false
+        }
     }
 }

--- a/src/lib/Query/Common/CriterionVisitor/DateMetadata/PublishedBetween.php
+++ b/src/lib/Query/Common/CriterionVisitor/DateMetadata/PublishedBetween.php
@@ -23,16 +23,21 @@ class PublishedBetween extends DateMetadata
      */
     public function canVisit(Criterion $criterion)
     {
-        return
-            $criterion instanceof Criterion\DateMetadata &&
-            $criterion->target === 'created' &&
-            (
-                $criterion->operator === Operator::LT ||
-                $criterion->operator === Operator::LTE ||
-                $criterion->operator === Operator::GT ||
-                $criterion->operator === Operator::GTE ||
-                $criterion->operator === Operator::BETWEEN
-            );
+        if (!$criterion instanceof Criterion\DateMetadata) {
+            return false;
+        }
+
+        if (!in_array($criterion->target, [Criterion\DateMetadata::PUBLISHED, Criterion\DateMetadata::CREATED])) {
+            return false;
+        }
+
+        return in_array($criterion->operator, [
+            Operator::LT,
+            Operator::LTE,
+            Operator::GT,
+            Operator::GTE,
+            Operator::BETWEEN,
+        ], true);
     }
 
     /**

--- a/src/lib/Query/Common/CriterionVisitor/DateMetadata/PublishedIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/DateMetadata/PublishedIn.php
@@ -23,13 +23,17 @@ class PublishedIn extends DateMetadata
      */
     public function canVisit(Criterion $criterion)
     {
-        return
-            $criterion instanceof Criterion\DateMetadata &&
-            $criterion->target === 'created' &&
-            (
-                ($criterion->operator ?: Operator::IN) === Operator::IN ||
-                $criterion->operator === Operator::EQ
-            );
+        if (!$criterion instanceof Criterion\DateMetadata) {
+            return false;
+        }
+
+        if (!in_array($criterion->target, [Criterion\DateMetadata::PUBLISHED, Criterion\DateMetadata::CREATED])) {
+            return false;
+        }
+
+        $operator = $criterion->operator ?: Operator::IN;
+
+        return in_array($operator, [Operator::IN, Operator::EQ], true);
     }
 
     /**


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | [IBX-5061](https://issues.ibexa.co/browse/IBX-5061) |
| **Type**                 | improvement                            |
| **Target Ibexa version** | `v4.3`              |
| **BC breaks**            | no                                              |

For legacy search engine, both "published" and "created" targets work for DateMetadata criterion.

Reading through the code, both actually relate to the same column.

However, when working with Solr/Elasticsearch, only "created" criterion works. I assumed that would be because it actually is capable of querying for creation date, but what actually happens is we query publication date (in both cases).

https://github.com/ibexa/solr/blob/23c21d004cd9902de9c5be04a110e8ce8fda83f4/src/lib/Query/Common/CriterionVisitor/DateMetadata/PublishedIn.php#L48

This PR adds `published` as a valid `DateMetadata` target, since Legacy search engine treats both `published` and `created` identically, and `created` in Solr implementation actually refers to `published` index.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for front-end changes).



