### PR TITLE
Fixed deprecation notices in string interpolation with PHP 8.2

### DIFF
--- a/src/lib/Container/Compiler/AggregateFacetBuilderVisitorPass.php
+++ b/src/lib/Container/Compiler/AggregateFacetBuilderVisitorPass.php
@@ -23,15 +23,15 @@ class AggregateFacetBuilderVisitorPass implements CompilerPassInterface
 
     private function processVisitors(ContainerBuilder $container, $name = 'content')
     {
-        if (!$container->hasDefinition("ibexa.solr.query.${name}.facet_builder_visitor.aggregate")) {
+        if (!$container->hasDefinition("ibexa.solr.query.$name.facet_builder_visitor.aggregate")) {
             return;
         }
 
         $aggregateFacetBuilderVisitorDefinition = $container->getDefinition(
-            "ibexa.solr.query.${name}.facet_builder_visitor.aggregate"
+            "ibexa.solr.query.$name.facet_builder_visitor.aggregate"
         );
 
-        foreach ($container->findTaggedServiceIds("ibexa.search.solr.query.${name}.facet_builder.visitor") as $id => $attributes) {
+        foreach ($container->findTaggedServiceIds("ibexa.search.solr.query.$name.facet_builder.visitor") as $id => $attributes) {
             $aggregateFacetBuilderVisitorDefinition->addMethodCall(
                 'addVisitor',
                 [

--- a/src/lib/Query/Common/AggregationVisitor/AbstractRangeAggregationVisitor.php
+++ b/src/lib/Query/Common/AggregationVisitor/AbstractRangeAggregationVisitor.php
@@ -30,7 +30,7 @@ abstract class AbstractRangeAggregationVisitor implements AggregationVisitor
             $from = $this->formatRangeValue($range->getFrom());
             $to = $this->formatRangeValue($range->getTo());
 
-            $rangeFacets["${from}_${to}"] = [
+            $rangeFacets["{$from}_{$to}"] = [
                 'type' => 'query',
                 'q' => sprintf('%s:[%s TO %s}', $field, $from, $to),
             ];

--- a/src/lib/Query/Common/FacetBuilderVisitor/ContentType.php
+++ b/src/lib/Query/Common/FacetBuilderVisitor/ContentType.php
@@ -45,7 +45,7 @@ class ContentType extends FacetBuilderVisitor implements FacetFieldVisitor
     public function visitBuilder(FacetBuilder $facetBuilder, $fieldId)
     {
         return [
-            'facet.field' => "{!ex=dt key=${fieldId}}content_type_id_id",
+            'facet.field' => "{!ex=dt key=$fieldId}content_type_id_id",
             'f.content_type_id_id.facet.limit' => $facetBuilder->limit,
             'f.content_type_id_id.facet.mincount' => $facetBuilder->minCount,
         ];

--- a/src/lib/Query/Common/FacetBuilderVisitor/Section.php
+++ b/src/lib/Query/Common/FacetBuilderVisitor/Section.php
@@ -45,7 +45,7 @@ class Section extends FacetBuilderVisitor implements FacetFieldVisitor
     public function visitBuilder(FacetBuilder $facetBuilder, $fieldId)
     {
         return [
-            'facet.field' => "{!ex=dt key=${fieldId}}content_section_id_id",
+            'facet.field' => "{!ex=dt key=$fieldId}content_section_id_id",
             'f.content_section_id_id.facet.limit' => $facetBuilder->limit,
             'f.content_section_id_id.facet.mincount' => $facetBuilder->minCount,
         ];

--- a/src/lib/Query/Common/FacetBuilderVisitor/User.php
+++ b/src/lib/Query/Common/FacetBuilderVisitor/User.php
@@ -58,9 +58,9 @@ class User extends FacetBuilderVisitor implements FacetFieldVisitor
         $field = self::DOC_FIELD_MAP[$facetBuilder->type];
 
         return [
-            'facet.field' => "{!ex=dt key=${fieldId}}$field",
-            "f.${field}.facet.limit" => $facetBuilder->limit,
-            "f.${field}.facet.mincount" => $facetBuilder->minCount,
+            'facet.field' => "{!ex=dt key=$fieldId}$field",
+            "f.$field.facet.limit" => $facetBuilder->limit,
+            "f.$field.facet.mincount" => $facetBuilder->minCount,
         ];
     }
 }

--- a/src/lib/Query/FacetFieldVisitor.php
+++ b/src/lib/Query/FacetFieldVisitor.php
@@ -29,7 +29,7 @@ interface FacetFieldVisitor
      *
      * Example:
      *        return array(
-     *            'facet.field' => "{!ex=dt key=${fieldId}}content_type_id_id",
+     *            'facet.field' => "{!ex=dt key=$fieldId}content_type_id_id",
      *            'f.content_type_id_id.facet.limit' => $facetBuilder->limit,
      *            'f.content_type_id_id.facet.mincount' => $facetBuilder->minCount,
      *        );

--- a/src/lib/ResultExtractor.php
+++ b/src/lib/ResultExtractor.php
@@ -157,8 +157,8 @@ abstract class ResultExtractor
                         @trigger_error(
                             'Not setting id of field using FacetFieldVisitor::visitBuilder will not be supported in 4.0'
                             . ', as it makes it impossible to exactly identify which facets belongs to which builder.'
-                            . "\nMake sure to adapt your visitor for the following field: ${field}"
-                            . "\nExample: 'facet.field' => \"{!ex=dt key=\${id}}${field}\",",
+                            . "\nMake sure to adapt your visitor for the following field: $field"
+                            . "\nExample: 'facet.field' => \"{!ex=dt key=\$id}$field\",",
                             E_USER_DEPRECATED
                         );
                     }


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           |                                                     |
| **Type**                 | improvement                                         |
| **Target Ibexa version** | `v4.3`                                              |
| **BC breaks**            | no                                                  |

Fixes new PHP 8.2 deprecation notices:
`Deprecated: Using ${var} in strings is deprecated, use {$var} instead in ...`

#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [ ] Provided automated test coverage.
- [X] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for front-end changes).
