### PR TITLE
Added missing PHPStan declaration for AggregationVisitor

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,6 +31,16 @@ parameters:
 			path: src/bundle/DependencyInjection/Configuration.php
 
 		-
+			message: "#^Method Ibexa\\\\Bundle\\\\Solr\\\\DependencyInjection\\\\Configuration\\:\\:addConnectionsSection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/bundle/DependencyInjection/Configuration.php
+
+		-
+			message: "#^Method Ibexa\\\\Bundle\\\\Solr\\\\DependencyInjection\\\\Configuration\\:\\:addEndpointsSection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/bundle/DependencyInjection/Configuration.php
+
+		-
 			message: "#^Property Ibexa\\\\Bundle\\\\Solr\\\\DependencyInjection\\\\Configuration\\:\\:\\$defaultEndpointValues type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/bundle/DependencyInjection/Configuration.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,16 +31,6 @@ parameters:
 			path: src/bundle/DependencyInjection/Configuration.php
 
 		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Solr\\\\DependencyInjection\\\\Configuration\\:\\:addConnectionsSection\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/DependencyInjection/Configuration.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Solr\\\\DependencyInjection\\\\Configuration\\:\\:addEndpointsSection\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/DependencyInjection/Configuration.php
-
-		-
 			message: "#^Property Ibexa\\\\Bundle\\\\Solr\\\\DependencyInjection\\\\Configuration\\:\\:\\$defaultEndpointValues type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/bundle/DependencyInjection/Configuration.php
@@ -139,16 +129,6 @@ parameters:
 			message: "#^Method Ibexa\\\\Bundle\\\\Solr\\\\IbexaSolrBundle\\:\\:build\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/bundle/IbexaSolrBundle.php
-
-		-
-			message: "#^Method Ibexa\\\\Contracts\\\\Solr\\\\Query\\\\AggregationVisitor\\:\\:canVisit\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/contracts/Query/AggregationVisitor.php
-
-		-
-			message: "#^Method Ibexa\\\\Contracts\\\\Solr\\\\Query\\\\AggregationVisitor\\:\\:visit\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/contracts/Query/AggregationVisitor.php
 
 		-
 			message: "#^Method Ibexa\\\\Contracts\\\\Solr\\\\Query\\\\CriterionVisitor\\:\\:escapeQuote\\(\\) should return string but returns string\\|null\\.$#"
@@ -556,6 +536,11 @@ parameters:
 			path: src/lib/Gateway/Message.php
 
 		-
+			message: "#^Default value of the parameter \\#2 \\$languageSettings \\(array\\{\\}\\) of method Ibexa\\\\Solr\\\\Gateway\\\\Native\\:\\:findContent\\(\\) is incompatible with type array\\{languages\\: array\\<string\\>\\}\\.$#"
+			count: 1
+			path: src/lib/Gateway/Native.php
+
+		-
 			message: "#^Method Ibexa\\\\Solr\\\\Gateway\\\\Native\\:\\:commit\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/lib/Gateway/Native.php
@@ -567,11 +552,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\Solr\\\\Gateway\\\\Native\\:\\:doBulkIndexDocuments\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Gateway/Native.php
-
-		-
-			message: "#^Method Ibexa\\\\Solr\\\\Gateway\\\\Native\\:\\:findContent\\(\\) has parameter \\$languageSettings with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Gateway/Native.php
 
@@ -786,29 +766,14 @@ parameters:
 			path: src/lib/Query/Common/AggregationVisitor/AbstractRangeAggregationVisitor.php
 
 		-
-			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\AbstractRangeAggregationVisitor\\:\\:visit\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Query/Common/AggregationVisitor/AbstractRangeAggregationVisitor.php
-
-		-
 			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\AbstractRangeAggregationVisitor\\:\\:visit\\(\\) should return array\\<string\\> but returns array\\<string, array\\<string, array\\<string, string\\>\\>\\|string\\>\\.$#"
 			count: 1
 			path: src/lib/Query/Common/AggregationVisitor/AbstractRangeAggregationVisitor.php
 
 		-
-			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\AbstractStatsAggregationVisitor\\:\\:visit\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Query/Common/AggregationVisitor/AbstractStatsAggregationVisitor.php
-
-		-
 			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\AbstractStatsAggregationVisitor\\:\\:visit\\(\\) should return array\\<string\\> but returns array\\<string, array\\<string, string\\>\\|string\\>\\.$#"
 			count: 1
 			path: src/lib/Query/Common/AggregationVisitor/AbstractStatsAggregationVisitor.php
-
-		-
-			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\AbstractTermAggregationVisitor\\:\\:visit\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Query/Common/AggregationVisitor/AbstractTermAggregationVisitor.php
 
 		-
 			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\AbstractTermAggregationVisitor\\:\\:visit\\(\\) should return array\\<string\\> but returns array\\<string, int\\|string\\>\\.$#"
@@ -826,94 +791,14 @@ parameters:
 			path: src/lib/Query/Common/AggregationVisitor/AggregationFieldResolver/RawAggregationFieldResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\DateMetadataRangeAggregationVisitor\\:\\:canVisit\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Query/Common/AggregationVisitor/DateMetadataRangeAggregationVisitor.php
-
-		-
-			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\DispatcherAggregationVisitor\\:\\:__construct\\(\\) has parameter \\$visitors with no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: src/lib/Query/Common/AggregationVisitor/DispatcherAggregationVisitor.php
-
-		-
-			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\DispatcherAggregationVisitor\\:\\:canVisit\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Query/Common/AggregationVisitor/DispatcherAggregationVisitor.php
-
-		-
-			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\DispatcherAggregationVisitor\\:\\:findVisitor\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Query/Common/AggregationVisitor/DispatcherAggregationVisitor.php
-
-		-
-			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\DispatcherAggregationVisitor\\:\\:visit\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Query/Common/AggregationVisitor/DispatcherAggregationVisitor.php
-
-		-
-			message: "#^PHPDoc tag @var above a method has no effect\\.$#"
-			count: 1
-			path: src/lib/Query/Common/AggregationVisitor/DispatcherAggregationVisitor.php
-
-		-
-			message: "#^PHPDoc tag @var does not specify variable name\\.$#"
-			count: 1
-			path: src/lib/Query/Common/AggregationVisitor/DispatcherAggregationVisitor.php
-
-		-
-			message: "#^Property Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\DispatcherAggregationVisitor\\:\\:\\$visitors \\(array\\<Ibexa\\\\Contracts\\\\Solr\\\\Query\\\\AggregationVisitor\\>\\) does not accept iterable\\.$#"
-			count: 1
-			path: src/lib/Query/Common/AggregationVisitor/DispatcherAggregationVisitor.php
-
-		-
-			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\ObjectStateAggregationVisitor\\:\\:canVisit\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Query/Common/AggregationVisitor/ObjectStateAggregationVisitor.php
-
-		-
-			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\ObjectStateAggregationVisitor\\:\\:visit\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Query/Common/AggregationVisitor/ObjectStateAggregationVisitor.php
-
-		-
 			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\ObjectStateAggregationVisitor\\:\\:visit\\(\\) should return array\\<string\\> but returns array\\<string, int\\|string\\>\\.$#"
 			count: 1
 			path: src/lib/Query/Common/AggregationVisitor/ObjectStateAggregationVisitor.php
 
 		-
-			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\RangeAggregationVisitor\\:\\:canVisit\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Query/Common/AggregationVisitor/RangeAggregationVisitor.php
-
-		-
-			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\StatsAggregationVisitor\\:\\:canVisit\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Query/Common/AggregationVisitor/StatsAggregationVisitor.php
-
-		-
-			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\SubtreeTermAggregationVisitor\\:\\:canVisit\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Query/Common/AggregationVisitor/SubtreeTermAggregationVisitor.php
-
-		-
-			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\SubtreeTermAggregationVisitor\\:\\:visit\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Query/Common/AggregationVisitor/SubtreeTermAggregationVisitor.php
-
-		-
 			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\SubtreeTermAggregationVisitor\\:\\:visit\\(\\) should return array\\<string\\> but returns array\\<string, array\\<string, array\\<string, int\\|string\\>\\>\\|string\\>\\.$#"
 			count: 1
 			path: src/lib/Query/Common/AggregationVisitor/SubtreeTermAggregationVisitor.php
-
-		-
-			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\TermAggregationVisitor\\:\\:canVisit\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Query/Common/AggregationVisitor/TermAggregationVisitor.php
-
-		-
-			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\AggregationVisitor\\\\UserMetadataTermAggregationVisitor\\:\\:canVisit\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Query/Common/AggregationVisitor/UserMetadataTermAggregationVisitor.php
 
 		-
 			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\CriterionVisitor\\\\Aggregate\\:\\:addVisitor\\(\\) has no return type specified\\.$#"
@@ -1146,7 +1031,7 @@ parameters:
 			path: src/lib/Query/Common/FacetBuilderVisitor/User.php
 
 		-
-			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\Common\\\\QueryConverter\\\\NativeQueryConverter\\:\\:convert\\(\\) has parameter \\$languageSettings with no value type specified in iterable type array\\.$#"
+			message: "#^Default value of the parameter \\#2 \\$languageSettings \\(array\\{\\}\\) of method Ibexa\\\\Solr\\\\Query\\\\Common\\\\QueryConverter\\\\NativeQueryConverter\\:\\:convert\\(\\) is incompatible with type array\\{languages\\: array\\<string\\>\\}\\.$#"
 			count: 1
 			path: src/lib/Query/Common/QueryConverter/NativeQueryConverter.php
 
@@ -1341,7 +1226,7 @@ parameters:
 			path: src/lib/Query/Location/CriterionVisitor/Visibility.php
 
 		-
-			message: "#^Method Ibexa\\\\Solr\\\\Query\\\\QueryConverter\\:\\:convert\\(\\) has parameter \\$languageSettings with no value type specified in iterable type array\\.$#"
+			message: "#^Default value of the parameter \\#2 \\$languageSettings \\(array\\{\\}\\) of method Ibexa\\\\Solr\\\\Query\\\\QueryConverter\\:\\:convert\\(\\) is incompatible with type array\\{languages\\: array\\<string\\>\\}\\.$#"
 			count: 1
 			path: src/lib/Query/QueryConverter.php
 
@@ -2009,116 +1894,6 @@ parameters:
 			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Gateway\\\\EndpointTest\\:\\:testEndpointDsnParsingWithoutUser\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/lib/Search/Gateway/EndpointTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\AbstractAggregationVisitorTest\\:\\:configureMocksForTestVisit\\(\\) has parameter \\$expectedResult with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/AbstractAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\AbstractAggregationVisitorTest\\:\\:configureMocksForTestVisit\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/AbstractAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\AbstractAggregationVisitorTest\\:\\:dataProviderForCanVisit\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/AbstractAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\AbstractAggregationVisitorTest\\:\\:dataProviderForVisit\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/AbstractAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\AbstractAggregationVisitorTest\\:\\:testCanVisit\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/AbstractAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\AbstractAggregationVisitorTest\\:\\:testVisit\\(\\) has parameter \\$expectedResult with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/AbstractAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\AbstractAggregationVisitorTest\\:\\:testVisit\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/AbstractAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\DateMetadataRangeAggregationVisitorTest\\:\\:dataProviderForCanVisit\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/DateMetadataRangeAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\DateMetadataRangeAggregationVisitorTest\\:\\:dataProviderForVisit\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/DateMetadataRangeAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\DispatcherAggregationVisitorTest\\:\\:createVisitorMock\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/DispatcherAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\ObjectStateGroupAggregationVisitorTest\\:\\:dataProviderForCanVisit\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/ObjectStateGroupAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\ObjectStateGroupAggregationVisitorTest\\:\\:dataProviderForVisit\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/ObjectStateGroupAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\RangeAggregationVisitorTest\\:\\:dataProviderForCanVisit\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/RangeAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\RangeAggregationVisitorTest\\:\\:dataProviderForVisit\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/RangeAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\StatsAggregationVisitorTest\\:\\:dataProviderForCanVisit\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/StatsAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\StatsAggregationVisitorTest\\:\\:dataProviderForVisit\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/StatsAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\SubtreeTermAggregationVisitorTest\\:\\:dataProviderForCanVisit\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/SubtreeTermAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\SubtreeTermAggregationVisitorTest\\:\\:dataProviderForVisit\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/SubtreeTermAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\TermAggregationVisitorTest\\:\\:dataProviderForCanVisit\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/TermAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\TermAggregationVisitorTest\\:\\:dataProviderForVisit\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/TermAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\UserMetadataTermAggregationVisitorTest\\:\\:dataProviderForCanVisit\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/UserMetadataTermAggregationVisitorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Common\\\\AggregationVisitor\\\\UserMetadataTermAggregationVisitorTest\\:\\:dataProviderForVisit\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: tests/lib/Search/Query/Common/AggregationVisitor/UserMetadataTermAggregationVisitorTest.php
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Solr\\\\Search\\\\Query\\\\Content\\\\CriterionVisitor\\\\FullTextTest\\:\\:getFullTextCriterionVisitor\\(\\) has no return type specified\\.$#"

--- a/src/contracts/Query/AggregationVisitor.php
+++ b/src/contracts/Query/AggregationVisitor.php
@@ -14,10 +14,14 @@ interface AggregationVisitor
 {
     /**
      * Check if visitor is applicable to current aggreagtion.
+     *
+     * @param array{languages: string[]} $languageFilter
      */
     public function canVisit(Aggregation $aggregation, array $languageFilter): bool;
 
     /**
+     * @param array{languages: string[]} $languageFilter
+     *
      * @return string[]
      */
     public function visit(

--- a/src/lib/Gateway/Native.php
+++ b/src/lib/Gateway/Native.php
@@ -85,6 +85,7 @@ class Native extends Gateway
      * Returns search hits for the given query.
      *
      * @phpstan-param array{languages: string[]} $languageSettings
+     *
      * @param array $languageSettings - a map of filters for the returned fields.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      *

--- a/src/lib/Gateway/Native.php
+++ b/src/lib/Gateway/Native.php
@@ -84,6 +84,7 @@ class Native extends Gateway
     /**
      * Returns search hits for the given query.
      *
+     * @phpstan-param array{languages: string[]} $languageSettings
      * @param array $languageSettings - a map of filters for the returned fields.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      *

--- a/src/lib/Query/Common/AggregationVisitor/DispatcherAggregationVisitor.php
+++ b/src/lib/Query/Common/AggregationVisitor/DispatcherAggregationVisitor.php
@@ -14,11 +14,11 @@ use Ibexa\Contracts\Solr\Query\AggregationVisitor;
 
 final class DispatcherAggregationVisitor implements AggregationVisitor
 {
-    /** @var \Ibexa\Contracts\Solr\Query\AggregationVisitor[] */
+    /** @var iterable<\Ibexa\Contracts\Solr\Query\AggregationVisitor> */
     private $visitors;
 
     /**
-     * @var \Ibexa\Contracts\Solr\Query\AggregationVisitor[]
+     * @param iterable<\Ibexa\Contracts\Solr\Query\AggregationVisitor> $visitors
      */
     public function __construct(iterable $visitors)
     {
@@ -46,6 +46,9 @@ final class DispatcherAggregationVisitor implements AggregationVisitor
         return $visitor->visit($this, $aggregation, $languageFilter);
     }
 
+    /**
+     * @param array{languages: string[]} $languageFilter
+     */
     private function findVisitor(Aggregation $aggregation, array $languageFilter): ?AggregationVisitor
     {
         foreach ($this->visitors as $visitor) {

--- a/src/lib/Query/QueryConverter.php
+++ b/src/lib/Query/QueryConverter.php
@@ -16,6 +16,7 @@ abstract class QueryConverter
     /**
      * Map query to a proper Solr representation.
      *
+     * @phpstan-param array{languages: string[]} $languageSettings
      * @param array $languageSettings - a map of filters for the returned fields.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      *

--- a/src/lib/Query/QueryConverter.php
+++ b/src/lib/Query/QueryConverter.php
@@ -17,6 +17,7 @@ abstract class QueryConverter
      * Map query to a proper Solr representation.
      *
      * @phpstan-param array{languages: string[]} $languageSettings
+     *
      * @param array $languageSettings - a map of filters for the returned fields.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      *

--- a/tests/lib/Search/Query/Common/AggregationVisitor/AbstractAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/AbstractAggregationVisitorTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 abstract class AbstractAggregationVisitorTest extends TestCase
 {
     protected const EXAMPLE_LANGUAGE_FILTER = [
-        'languageCode' => 'eng-gb',
+        'languages' => ['eng-gb'],
     ];
 
     /** @var \Ibexa\Contracts\Solr\Query\AggregationVisitor */
@@ -33,6 +33,8 @@ abstract class AbstractAggregationVisitorTest extends TestCase
     abstract protected function createVisitor(): AggregationVisitor;
 
     /**
+     * @param array{languages: string[]} $languageFilter
+     *
      * @dataProvider dataProviderForCanVisit
      */
     final public function testCanVisit(
@@ -46,9 +48,19 @@ abstract class AbstractAggregationVisitorTest extends TestCase
         );
     }
 
+    /**
+     * @return iterable<array{
+     *     \Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation,
+     *     array{languages: string[]},
+     *     bool,
+     * }>
+     */
     abstract public function dataProviderForCanVisit(): iterable;
 
     /**
+     * @param array{languages: string[]} $languageFilter
+     * @param array<mixed> $expectedResult
+     *
      * @dataProvider dataProviderForVisit
      */
     final public function testVisit(
@@ -64,8 +76,19 @@ abstract class AbstractAggregationVisitorTest extends TestCase
         );
     }
 
+    /**
+     * @return iterable<array{
+     *     \Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation,
+     *     array{languages: string[]},
+     *     array<mixed>,
+     * }>
+     */
     abstract public function dataProviderForVisit(): iterable;
 
+    /**
+     * @param array{languages: string[]} $languageFilter
+     * @param array<mixed> $expectedResult
+     */
     protected function configureMocksForTestVisit(
         Aggregation $aggregation,
         array $languageFilter,

--- a/tests/lib/Search/Query/Common/AggregationVisitor/AbstractAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/AbstractAggregationVisitorTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 abstract class AbstractAggregationVisitorTest extends TestCase
 {
     protected const EXAMPLE_LANGUAGE_FILTER = [
-        'languages' => ['eng-gb'],
+        'languages' => ['eng-GB'],
     ];
 
     /** @var \Ibexa\Contracts\Solr\Query\AggregationVisitor */

--- a/tests/lib/Search/Query/Common/AggregationVisitor/DispatcherAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/DispatcherAggregationVisitorTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 final class DispatcherAggregationVisitorTest extends TestCase
 {
     private const EXAMPLE_LANGUAGE_FILTER = [
-        'languageCode' => 'eng-gb',
+        'languages' => ['eng-gb'],
     ];
 
     private const EXAMPLE_VISITOR_RESULT = [
@@ -74,6 +74,11 @@ final class DispatcherAggregationVisitorTest extends TestCase
         );
     }
 
+    /**
+     * @param array{languages: string[]} $languageFilter
+     *
+     * @return \PHPUnit\Framework\MockObject\MockObject&\Ibexa\Contracts\Solr\Query\AggregationVisitor
+     */
     private function createVisitorMock(
         Aggregation $aggregation,
         array $languageFilter,

--- a/tests/lib/Search/Query/Common/AggregationVisitor/DispatcherAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/DispatcherAggregationVisitorTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 final class DispatcherAggregationVisitorTest extends TestCase
 {
     private const EXAMPLE_LANGUAGE_FILTER = [
-        'languages' => ['eng-gb'],
+        'languages' => ['eng-GB'],
     ];
 
     private const EXAMPLE_VISITOR_RESULT = [


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | N/A |
| **Type**                 | improvement                             |
| **Target Ibexa version** | `v4.4`
| **BC breaks**            | no                                              |

Adds a proper data type for the `AggregationVisitor`, especially since it's not obvious.

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for front-end changes).
