### PR TITLE
Added `http_client.client` tag to the Solr HTTP Client

### DIFF
--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -21,6 +21,7 @@ services:
         calls:
             -   setLogger: [ '@logger' ]
         tags:
+            - { name: http_client.client }
             - { name: monolog.logger, channel: ibexa.solr }
 
     Ibexa\Solr\Gateway\HttpClient\Stream:

--- a/src/lib/Resources/config/container/solr.yml
+++ b/src/lib/Resources/config/container/solr.yml
@@ -150,4 +150,3 @@ services:
         tags:
             - {name: ibexa.search.engine.indexer, alias: solr}
         lazy: true
-


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | N/A |
| **Type**                 | improvement                             |
| **Target Ibexa version** | `v4.4`              |
| **BC breaks**            | no                                              |

Adds a `http_client.client` tag to the Solr HTTP Client, which should make it so it becomes decorated with `TraceableHttpClient` and added to profiler when Kernel is in debug mode.

See https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/HttpClient/DependencyInjection/HttpClientPass.php

Should make #28 obsolete.

![image](https://user-images.githubusercontent.com/3183926/228182401-7e5ce4d0-b613-4579-9f61-fcf7b3bcedbd.png)

Confirmed locally on 4.4.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for front-end changes).
