### PR TITLE
IBX-4929: Fix PhpDoc

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -321,7 +321,7 @@ parameters:
 			path: src/lib/FieldMapper/ContentFieldMapper/ContentDocumentLocationFields.php
 
 		-
-			message: "#^Offset 'ancestors' does not exist on array\\{ancestors\\?\\: non\\-empty\\-array\\<int, mixed\\>, ids\\: non\\-empty\\-array\\<int, mixed\\>, parent_ids\\: non\\-empty\\-array\\<int, mixed\\>, path_strings\\: non\\-empty\\-array\\<int, string\\>, remote_ids\\: non\\-empty\\-array\\<int, mixed\\>\\}\\.$#"
+			message: "#^Offset 'ancestors' does not exist on array\\{ancestors\\?\\: non\\-empty\\-array\\<int\\<0, max\\>, mixed\\>, ids\\: non\\-empty\\-array\\<int\\<0, max\\>, mixed\\>, parent_ids\\: non\\-empty\\-array\\<int\\<0, max\\>, mixed\\>, path_strings\\: non\\-empty\\-array\\<int\\<0, max\\>, string\\>, remote_ids\\: non\\-empty\\-array\\<int\\<0, max\\>, mixed\\>\\}\\.$#"
 			count: 1
 			path: src/lib/FieldMapper/ContentFieldMapper/ContentDocumentLocationFields.php
 
@@ -502,11 +502,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\Solr\\\\Gateway\\\\EndpointRegistry\\:\\:registerEndpoint\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Gateway/EndpointRegistry.php
-
-		-
-			message: "#^Property Ibexa\\\\Solr\\\\Gateway\\\\EndpointRegistry\\:\\:\\$endpoint type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Gateway/EndpointRegistry.php
 
@@ -1262,11 +1257,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\Solr\\\\ResultExtractor\\:\\:extractSearchHit\\(\\) has parameter \\$languageFilter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/ResultExtractor.php
-
-		-
-			message: "#^Method Ibexa\\\\Solr\\\\ResultExtractor\\:\\:getMatchedLanguageCode\\(\\) has parameter \\$hit with no type specified\\.$#"
 			count: 1
 			path: src/lib/ResultExtractor.php
 

--- a/src/contracts/Query/AggregationVisitor.php
+++ b/src/contracts/Query/AggregationVisitor.php
@@ -15,12 +15,12 @@ interface AggregationVisitor
     /**
      * Check if visitor is applicable to current aggreagtion.
      *
-     * @param array{languages: string[]} $languageFilter
+     * @phpstan-param array{languages: string[]} $languageFilter
      */
     public function canVisit(Aggregation $aggregation, array $languageFilter): bool;
 
     /**
-     * @param array{languages: string[]} $languageFilter
+     * @phpstan-param array{languages: string[]} $languageFilter
      *
      * @return string[]
      */

--- a/src/lib/Gateway/EndpointRegistry.php
+++ b/src/lib/Gateway/EndpointRegistry.php
@@ -16,7 +16,7 @@ class EndpointRegistry
     /**
      * Registered endpoints.
      *
-     * @var array(string => Endpoint)
+     * @var array<string, Endpoint>
      */
     protected $endpoint = [];
 

--- a/src/lib/ResultExtractor.php
+++ b/src/lib/ResultExtractor.php
@@ -83,7 +83,7 @@ abstract class ResultExtractor
     /**
      * Returns language code of the Content's translation of the matched document.
      *
-     * @param $hit
+     * @param mixed $hit
      *
      * @return string
      */


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | [IBX-4929](https://issues.ibexa.co/browse/IBX-4929) |
| **Type**                 | bug                             |
| **Target Ibexa version** | `v4.x` - please update `x` accordingly              |
| **BC breaks**            | no                                              |

- Fix a `@var` syntax (php-like to phpdoc)
- Add missing type to a `@param`
- Move extended syntax from `@param` to `@phpstan-param`

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for front-end changes).
