### PR TITLE
Skipped generating solrconfig.xml file copies in generate-solr-config.sh

### DIFF
--- a/bin/generate-solr-config.sh
+++ b/bin/generate-solr-config.sh
@@ -119,8 +119,8 @@ else
 fi
 
 # Adapt autoSoftCommit to have a recommended value, and remove add-unknown-fields-to-the-schema
-sed -i.bak '/<updateRequestProcessorChain name="add-unknown-fields-to-the-schema".*/,/<\/updateRequestProcessorChain>/d' $DESTINATION_DIR/solrconfig.xml
-sed -i.bak2 's/${solr.autoSoftCommit.maxTime:-1}/${solr.autoSoftCommit.maxTime:20}/' $DESTINATION_DIR/solrconfig.xml
+sed -i '/<updateRequestProcessorChain name="add-unknown-fields-to-the-schema".*/,/<\/updateRequestProcessorChain>/d' $DESTINATION_DIR/solrconfig.xml
+sed -i 's/${solr.autoSoftCommit.maxTime:-1}/${solr.autoSoftCommit.maxTime:20}/' $DESTINATION_DIR/solrconfig.xml
 
 if [ "$GENERATE_SOLR_TMPDIR" != "" ]; then
     echo Removing temp dir: $GENERATE_SOLR_TMPDIR

--- a/bin/generate-solr-config.sh
+++ b/bin/generate-solr-config.sh
@@ -119,8 +119,10 @@ else
 fi
 
 # Adapt autoSoftCommit to have a recommended value, and remove add-unknown-fields-to-the-schema
-sed -i '/<updateRequestProcessorChain name="add-unknown-fields-to-the-schema".*/,/<\/updateRequestProcessorChain>/d' $DESTINATION_DIR/solrconfig.xml
-sed -i 's/${solr.autoSoftCommit.maxTime:-1}/${solr.autoSoftCommit.maxTime:20}/' $DESTINATION_DIR/solrconfig.xml
+sed -i.bak '/<updateRequestProcessorChain name="add-unknown-fields-to-the-schema".*/,/<\/updateRequestProcessorChain>/d' $DESTINATION_DIR/solrconfig.xml
+sed -i.bak 's/${solr.autoSoftCommit.maxTime:-1}/${solr.autoSoftCommit.maxTime:20}/' $DESTINATION_DIR/solrconfig.xml
+
+rm $DESTINATION_DIR/solrconfig.xml.bak
 
 if [ "$GENERATE_SOLR_TMPDIR" != "" ]; then
     echo Removing temp dir: $GENERATE_SOLR_TMPDIR


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | N/A  |
| **Type**                 | bug                             |
| **Target Ibexa version** | `v4.5`|
| **BC breaks**            | no                                              |

Skipped generating `solrconfig.xml` file copies in `bin/generate-solr-config.sh`: `solrconfig.xml.bak` and `solrconfig.xml.bak2`

#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [ ] ~Provided automated test coverage.~
- [X] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] ~Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).~
- [ ] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for front-end changes).
