### PR TITLE
Fixed distribution link forcing https redirection

### DIFF
--- a/.github/init_solr.sh
+++ b/.github/init_solr.sh
@@ -46,7 +46,7 @@ download() {
     case ${SOLR_VERSION} in
         # PS!!: Append versions and don't remove old ones (except in major versions), used in integration tests from other packages!
         7.7.* | 8.* )
-            url="http://archive.apache.org/dist/lucene/solr/${SOLR_VERSION}/solr-${SOLR_VERSION}.tgz"
+            url="https://archive.apache.org/dist/lucene/solr/${SOLR_VERSION}/solr-${SOLR_VERSION}.tgz"
             ;;
         *)
             echo "Version '${SOLR_VERSION}' is not supported or not valid"


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | CI issue |
| **Type**                 | improvement                             |
| **Target Ibexa version** | `v4.5`              |
| **BC breaks**            | no                                              |

Fixed links in installation script to use https, instead of http.

Another option is to also add `-L` option to `curl` call, making the installation follow any redirects. I opted to not do that, so that we would have broken tests when links change (if).

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for front-end changes).
