### PR TITLE
IBX-8119: Upgraded minimum PHP version to 8.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,9 +14,9 @@ jobs:
         strategy:
             matrix:
                 php:
-                    - '8.0'
+                    - '8.3'
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
@@ -26,7 +26,7 @@ jobs:
                   extensions: 'pdo_sqlite, gd'
                   tools: cs2pr
 
-            - uses: ramsey/composer-install@v2
+            - uses: ramsey/composer-install@v3
               with:
                   dependency-versions: highest
 
@@ -42,12 +42,10 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - '7.4'
-                    - '8.0'
-                    - '8.1'
+                    - '8.3'
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
@@ -57,7 +55,7 @@ jobs:
                   extensions: pdo_sqlite, gd
                   tools: cs2pr
 
-            - uses: ramsey/composer-install@v2
+            - uses: ramsey/composer-install@v3
               with:
                   dependency-versions: highest
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -14,6 +14,8 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
+                php-version:
+                    - '8.3'
                 solr-version:
                     - '7.7.3'
                     - '8.11.2'
@@ -34,15 +36,15 @@ jobs:
               name: "Set up single core"
               run: echo "SOLR_CORES=collection1" >> $GITHUB_ENV
 
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.4
+                  php-version: ${{ matrix.php-version }}
                   coverage: none
 
-            - uses: ramsey/composer-install@v2
+            - uses: ramsey/composer-install@v3
               with:
                   dependency-versions: highest
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": ">=8.3",
         "ext-json": "*",
         "ext-xmlwriter": "*",
         "ibexa/core": "~5.0.0@dev",
@@ -26,15 +26,15 @@
         "symfony/http-client": "^5.4"
     },
     "require-dev": {
-        "symfony/proxy-manager-bridge": "^5.4",
-        "symfony/phpunit-bridge": "^5.4",
+        "ibexa/code-style": "~2.0.0",
         "ibexa/doctrine-schema": "~5.0.0@dev",
-        "phpunit/phpunit": "^8.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
-        "ibexa/code-style": "^1.0",
         "phpstan/phpstan": "^1.8",
         "phpstan/phpstan-phpunit": "^1.1",
-        "phpstan/phpstan-symfony": "^1.2"
+        "phpstan/phpstan-symfony": "^1.2",
+        "phpunit/phpunit": "^9.6",
+        "symfony/phpunit-bridge": "^5.4",
+        "symfony/proxy-manager-bridge": "^5.4"
     },
     "autoload": {
         "psr-4": {
@@ -74,6 +74,7 @@
         }
     },
     "config": {
-        "allow-plugins": false
+        "allow-plugins": false,
+        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=8.3",
         "ext-json": "*",
         "ext-xmlwriter": "*",
-        "ibexa/core": "~5.0.0@dev",
+        "ibexa/core": "~5.0.x-dev",
         "netgen/query-translator": "^1.0.2",
         "symfony/http-kernel": "^5.0",
         "symfony/dependency-injection": "^5.0",
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "ibexa/code-style": "~2.0.0",
-        "ibexa/doctrine-schema": "~5.0.0@dev",
+        "ibexa/doctrine-schema": "~5.0.x-dev",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "phpstan/phpstan": "^1.8",
         "phpstan/phpstan-phpunit": "^1.1",

--- a/src/bundle/ApiLoader/BoostFactorProviderFactory.php
+++ b/src/bundle/ApiLoader/BoostFactorProviderFactory.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Bundle\Solr\ApiLoader;
 
 use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;

--- a/src/bundle/ApiLoader/SolrEngineFactory.php
+++ b/src/bundle/ApiLoader/SolrEngineFactory.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Bundle\Solr\ApiLoader;
 
 use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Bundle\Solr\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;

--- a/src/bundle/DependencyInjection/IbexaSolrExtension.php
+++ b/src/bundle/DependencyInjection/IbexaSolrExtension.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Bundle\Solr\DependencyInjection;
 
 use Ibexa\Bundle\Solr\ApiLoader\BoostFactorProviderFactory;

--- a/src/bundle/IbexaSolrBundle.php
+++ b/src/bundle/IbexaSolrBundle.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Bundle\Solr;
 
 use Ibexa\Bundle\Solr\DependencyInjection\IbexaSolrExtension;

--- a/src/contracts/DocumentMapper.php
+++ b/src/contracts/DocumentMapper.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Contracts\Solr;
 
 use Ibexa\Contracts\Core\Persistence\Content;

--- a/src/contracts/FieldMapper/ContentFieldMapper.php
+++ b/src/contracts/FieldMapper/ContentFieldMapper.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Contracts\Solr\FieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content as SPIContent;

--- a/src/contracts/FieldMapper/ContentTranslationFieldMapper.php
+++ b/src/contracts/FieldMapper/ContentTranslationFieldMapper.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Contracts\Solr\FieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content as SPIContent;

--- a/src/contracts/FieldMapper/LocationFieldMapper.php
+++ b/src/contracts/FieldMapper/LocationFieldMapper.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Contracts\Solr\FieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content\Location as SPILocation;

--- a/src/contracts/Query/CriterionVisitor.php
+++ b/src/contracts/Query/CriterionVisitor.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Contracts\Solr\Query;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/contracts/Query/SortClauseVisitor.php
+++ b/src/contracts/Query/SortClauseVisitor.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Contracts\Solr\Query;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;

--- a/src/lib/Container/Compiler/AggregateCriterionVisitorPass.php
+++ b/src/lib/Container/Compiler/AggregateCriterionVisitorPass.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Container\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/src/lib/Container/Compiler/AggregateFacetBuilderVisitorPass.php
+++ b/src/lib/Container/Compiler/AggregateFacetBuilderVisitorPass.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Container\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/src/lib/Container/Compiler/AggregateSortClauseVisitorPass.php
+++ b/src/lib/Container/Compiler/AggregateSortClauseVisitorPass.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Container\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/src/lib/Container/Compiler/BaseFieldMapperPass.php
+++ b/src/lib/Container/Compiler/BaseFieldMapperPass.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Container\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/src/lib/Container/Compiler/CoreFilterRegistryPass.php
+++ b/src/lib/Container/Compiler/CoreFilterRegistryPass.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Container\Compiler;
 
 use Ibexa\Solr\CoreFilter\CoreFilterRegistry;

--- a/src/lib/Container/Compiler/EndpointRegistryPass.php
+++ b/src/lib/Container/Compiler/EndpointRegistryPass.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Container\Compiler;
 
 use Ibexa\Solr\Gateway\EndpointRegistry;

--- a/src/lib/Container/Compiler/FieldMapperPass/BlockFieldMapperPass.php
+++ b/src/lib/Container/Compiler/FieldMapperPass/BlockFieldMapperPass.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Container\Compiler\FieldMapperPass;
 
 use Ibexa\Solr\Container\Compiler\BaseFieldMapperPass;

--- a/src/lib/Container/Compiler/FieldMapperPass/BlockTranslationFieldMapperPass.php
+++ b/src/lib/Container/Compiler/FieldMapperPass/BlockTranslationFieldMapperPass.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Container\Compiler\FieldMapperPass;
 
 use Ibexa\Solr\Container\Compiler\BaseFieldMapperPass;

--- a/src/lib/Container/Compiler/FieldMapperPass/ContentFieldMapperPass.php
+++ b/src/lib/Container/Compiler/FieldMapperPass/ContentFieldMapperPass.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Container\Compiler\FieldMapperPass;
 
 use Ibexa\Solr\Container\Compiler\BaseFieldMapperPass;

--- a/src/lib/Container/Compiler/FieldMapperPass/ContentTranslationFieldMapperPass.php
+++ b/src/lib/Container/Compiler/FieldMapperPass/ContentTranslationFieldMapperPass.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Container\Compiler\FieldMapperPass;
 
 use Ibexa\Solr\Container\Compiler\BaseFieldMapperPass;

--- a/src/lib/Container/Compiler/FieldMapperPass/LocationFieldMapperPass.php
+++ b/src/lib/Container/Compiler/FieldMapperPass/LocationFieldMapperPass.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Container\Compiler\FieldMapperPass;
 
 use Ibexa\Solr\Container\Compiler\BaseFieldMapperPass;

--- a/src/lib/Container/Compiler/GatewayRegistryPass.php
+++ b/src/lib/Container/Compiler/GatewayRegistryPass.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Container\Compiler;
 
 use Ibexa\Solr\Gateway\GatewayRegistry;

--- a/src/lib/CoreFilter.php
+++ b/src/lib/CoreFilter.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;

--- a/src/lib/CoreFilter/CoreFilterRegistry.php
+++ b/src/lib/CoreFilter/CoreFilterRegistry.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\CoreFilter;
 
 use Ibexa\Solr\CoreFilter;

--- a/src/lib/CoreFilter/NativeCoreFilter.php
+++ b/src/lib/CoreFilter/NativeCoreFilter.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\CoreFilter;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;

--- a/src/lib/DocumentMapper/NativeDocumentMapper.php
+++ b/src/lib/DocumentMapper/NativeDocumentMapper.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\DocumentMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content;

--- a/src/lib/FieldMapper/BoostFactorProvider.php
+++ b/src/lib/FieldMapper/BoostFactorProvider.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\FieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content\Type as ContentType;

--- a/src/lib/FieldMapper/ContentFieldMapper/Aggregate.php
+++ b/src/lib/FieldMapper/ContentFieldMapper/Aggregate.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\FieldMapper\ContentFieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content;

--- a/src/lib/FieldMapper/ContentFieldMapper/BlockDocumentsBaseContentFields.php
+++ b/src/lib/FieldMapper/ContentFieldMapper/BlockDocumentsBaseContentFields.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\FieldMapper\ContentFieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content;

--- a/src/lib/FieldMapper/ContentFieldMapper/ContentDocumentBaseFields.php
+++ b/src/lib/FieldMapper/ContentFieldMapper/ContentDocumentBaseFields.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\FieldMapper\ContentFieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content;

--- a/src/lib/FieldMapper/ContentFieldMapper/ContentDocumentLocationFields.php
+++ b/src/lib/FieldMapper/ContentFieldMapper/ContentDocumentLocationFields.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\FieldMapper\ContentFieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content;

--- a/src/lib/FieldMapper/ContentTranslationFieldMapper/Aggregate.php
+++ b/src/lib/FieldMapper/ContentTranslationFieldMapper/Aggregate.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\FieldMapper\ContentTranslationFieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content;

--- a/src/lib/FieldMapper/ContentTranslationFieldMapper/BlockDocumentsContentFields.php
+++ b/src/lib/FieldMapper/ContentTranslationFieldMapper/BlockDocumentsContentFields.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\FieldMapper\ContentTranslationFieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content;

--- a/src/lib/FieldMapper/ContentTranslationFieldMapper/BlockDocumentsMetaFields.php
+++ b/src/lib/FieldMapper/ContentTranslationFieldMapper/BlockDocumentsMetaFields.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\FieldMapper\ContentTranslationFieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content;

--- a/src/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentFulltextFields.php
+++ b/src/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentFulltextFields.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\FieldMapper\ContentTranslationFieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content;

--- a/src/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentTranslatedContentNameField.php
+++ b/src/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentTranslatedContentNameField.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\FieldMapper\ContentTranslationFieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content;

--- a/src/lib/FieldMapper/LocationFieldMapper/Aggregate.php
+++ b/src/lib/FieldMapper/LocationFieldMapper/Aggregate.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\FieldMapper\LocationFieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content\Location;

--- a/src/lib/FieldMapper/LocationFieldMapper/LocationDocumentBaseFields.php
+++ b/src/lib/FieldMapper/LocationFieldMapper/LocationDocumentBaseFields.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\FieldMapper\LocationFieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content\Handler as ContentHandler;

--- a/src/lib/Gateway.php
+++ b/src/lib/Gateway.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;

--- a/src/lib/Gateway/Endpoint.php
+++ b/src/lib/Gateway/Endpoint.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Gateway;
 
 use Ibexa\Contracts\Core\Persistence\ValueObject;

--- a/src/lib/Gateway/EndpointRegistry.php
+++ b/src/lib/Gateway/EndpointRegistry.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Gateway;
 
 use OutOfBoundsException;

--- a/src/lib/Gateway/EndpointResolver.php
+++ b/src/lib/Gateway/EndpointResolver.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Gateway;
 
 /**

--- a/src/lib/Gateway/EndpointResolver/NativeEndpointResolver.php
+++ b/src/lib/Gateway/EndpointResolver/NativeEndpointResolver.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Gateway\EndpointResolver;
 
 use Ibexa\Solr\Gateway\EndpointResolver;

--- a/src/lib/Gateway/GatewayRegistry.php
+++ b/src/lib/Gateway/GatewayRegistry.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Gateway;
 
 use Ibexa\Solr\Gateway;

--- a/src/lib/Gateway/HttpClient.php
+++ b/src/lib/Gateway/HttpClient.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Gateway;
 
 /**

--- a/src/lib/Gateway/HttpClient/ConnectionException.php
+++ b/src/lib/Gateway/HttpClient/ConnectionException.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Gateway\HttpClient;
 
 use RuntimeException;

--- a/src/lib/Gateway/HttpClient/Stream.php
+++ b/src/lib/Gateway/HttpClient/Stream.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Gateway\HttpClient;
 
 use Ibexa\Solr\Gateway\Endpoint;

--- a/src/lib/Gateway/Message.php
+++ b/src/lib/Gateway/Message.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Gateway;
 
 /**

--- a/src/lib/Gateway/Native.php
+++ b/src/lib/Gateway/Native.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Gateway;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;

--- a/src/lib/Gateway/SingleEndpointResolver.php
+++ b/src/lib/Gateway/SingleEndpointResolver.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Gateway;
 
 /**

--- a/src/lib/Gateway/UpdateSerializer.php
+++ b/src/lib/Gateway/UpdateSerializer.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Gateway;
 
 use Ibexa\Solr\Gateway\UpdateSerializer\XmlUpdateSerializer;

--- a/src/lib/Gateway/UpdateSerializer/XmlUpdateSerializer.php
+++ b/src/lib/Gateway/UpdateSerializer/XmlUpdateSerializer.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Gateway\UpdateSerializer;
 
 use Ibexa\Contracts\Core\Search\Document;

--- a/src/lib/Handler.php
+++ b/src/lib/Handler.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr;
 
 use Ibexa\Contracts\Core\Persistence\Content;

--- a/src/lib/Indexer.php
+++ b/src/lib/Indexer.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr;
 
 use Doctrine\DBAL\Connection;

--- a/src/lib/Query/Common/CriterionVisitor/Aggregate.php
+++ b/src/lib/Query/Common/CriterionVisitor/Aggregate.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException;

--- a/src/lib/Query/Common/CriterionVisitor/ContentIdIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/ContentIdIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/ContentTypeGroupIdIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/ContentTypeGroupIdIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/ContentTypeIdIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/ContentTypeIdIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/ContentTypeIdentifierIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/ContentTypeIdentifierIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Persistence\Content\Type\Handler;

--- a/src/lib/Query/Common/CriterionVisitor/CustomField/CustomFieldIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/CustomField/CustomFieldIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor\CustomField;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/CustomField/CustomFieldRange.php
+++ b/src/lib/Query/Common/CriterionVisitor/CustomField/CustomFieldRange.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor\CustomField;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/DateMetadata.php
+++ b/src/lib/Query/Common/CriterionVisitor/DateMetadata.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor;
 
 use Exception;

--- a/src/lib/Query/Common/CriterionVisitor/DateMetadata/ModifiedBetween.php
+++ b/src/lib/Query/Common/CriterionVisitor/DateMetadata/ModifiedBetween.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor\DateMetadata;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/DateMetadata/ModifiedIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/DateMetadata/ModifiedIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor\DateMetadata;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/DateMetadata/PublishedBetween.php
+++ b/src/lib/Query/Common/CriterionVisitor/DateMetadata/PublishedBetween.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor\DateMetadata;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/DateMetadata/PublishedIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/DateMetadata/PublishedIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor\DateMetadata;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/Field.php
+++ b/src/lib/Query/Common/CriterionVisitor/Field.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/Field/FieldIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/Field/FieldIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor\Field;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/Field/FieldLike.php
+++ b/src/lib/Query/Common/CriterionVisitor/Field/FieldLike.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor\Field;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/Field/FieldRange.php
+++ b/src/lib/Query/Common/CriterionVisitor/Field/FieldRange.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor\Field;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/Field/FieldRelation.php
+++ b/src/lib/Query/Common/CriterionVisitor/Field/FieldRelation.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor\Field;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/LanguageCodeIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/LanguageCodeIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/LogicalAnd.php
+++ b/src/lib/Query/Common/CriterionVisitor/LogicalAnd.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/LogicalNot.php
+++ b/src/lib/Query/Common/CriterionVisitor/LogicalNot.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/LogicalOr.php
+++ b/src/lib/Query/Common/CriterionVisitor/LogicalOr.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/MapLocation.php
+++ b/src/lib/Query/Common/CriterionVisitor/MapLocation.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/MapLocation/MapLocationDistanceIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/MapLocation/MapLocationDistanceIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor\MapLocation;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/MapLocation/MapLocationDistanceRange.php
+++ b/src/lib/Query/Common/CriterionVisitor/MapLocation/MapLocationDistanceRange.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor\MapLocation;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/MatchAll.php
+++ b/src/lib/Query/Common/CriterionVisitor/MatchAll.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/MatchNone.php
+++ b/src/lib/Query/Common/CriterionVisitor/MatchNone.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/ObjectStateIdIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/ObjectStateIdIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/RemoteIdIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/RemoteIdIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/SectionIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/SectionIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Common/CriterionVisitor/UserMetadataIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/UserMetadataIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException;

--- a/src/lib/Query/Common/FacetBuilderVisitor/Aggregate.php
+++ b/src/lib/Query/Common/FacetBuilderVisitor/Aggregate.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\FacetBuilderVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\FacetBuilder;

--- a/src/lib/Query/Common/FacetBuilderVisitor/ContentType.php
+++ b/src/lib/Query/Common/FacetBuilderVisitor/ContentType.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\FacetBuilderVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\FacetBuilder;

--- a/src/lib/Query/Common/FacetBuilderVisitor/Section.php
+++ b/src/lib/Query/Common/FacetBuilderVisitor/Section.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\FacetBuilderVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\FacetBuilder;

--- a/src/lib/Query/Common/FacetBuilderVisitor/User.php
+++ b/src/lib/Query/Common/FacetBuilderVisitor/User.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\FacetBuilderVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\FacetBuilder;

--- a/src/lib/Query/Common/QueryConverter/NativeQueryConverter.php
+++ b/src/lib/Query/Common/QueryConverter/NativeQueryConverter.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\QueryConverter;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;

--- a/src/lib/Query/Common/QueryTranslator/Generator/WordVisitor.php
+++ b/src/lib/Query/Common/QueryTranslator/Generator/WordVisitor.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\QueryTranslator\Generator;
 
 use QueryTranslator\Languages\Galach\Generators\Common\Visitor;

--- a/src/lib/Query/Common/SortClauseVisitor/Aggregate.php
+++ b/src/lib/Query/Common/SortClauseVisitor/Aggregate.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\SortClauseVisitor;
 
 use Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException;

--- a/src/lib/Query/Common/SortClauseVisitor/ContentId.php
+++ b/src/lib/Query/Common/SortClauseVisitor/ContentId.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\SortClauseVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;

--- a/src/lib/Query/Common/SortClauseVisitor/ContentName.php
+++ b/src/lib/Query/Common/SortClauseVisitor/ContentName.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\SortClauseVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;

--- a/src/lib/Query/Common/SortClauseVisitor/DateModified.php
+++ b/src/lib/Query/Common/SortClauseVisitor/DateModified.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\SortClauseVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;

--- a/src/lib/Query/Common/SortClauseVisitor/DatePublished.php
+++ b/src/lib/Query/Common/SortClauseVisitor/DatePublished.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\SortClauseVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;

--- a/src/lib/Query/Common/SortClauseVisitor/Field.php
+++ b/src/lib/Query/Common/SortClauseVisitor/Field.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\SortClauseVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;

--- a/src/lib/Query/Common/SortClauseVisitor/MapLocationDistance.php
+++ b/src/lib/Query/Common/SortClauseVisitor/MapLocationDistance.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\SortClauseVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;

--- a/src/lib/Query/Common/SortClauseVisitor/Random.php
+++ b/src/lib/Query/Common/SortClauseVisitor/Random.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\SortClauseVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;

--- a/src/lib/Query/Common/SortClauseVisitor/SectionIdentifier.php
+++ b/src/lib/Query/Common/SortClauseVisitor/SectionIdentifier.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\SortClauseVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;

--- a/src/lib/Query/Common/SortClauseVisitor/SectionName.php
+++ b/src/lib/Query/Common/SortClauseVisitor/SectionName.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Common\SortClauseVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;

--- a/src/lib/Query/Content/CriterionVisitor/Ancestor.php
+++ b/src/lib/Query/Content/CriterionVisitor/Ancestor.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Content\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Content/CriterionVisitor/Field.php
+++ b/src/lib/Query/Content/CriterionVisitor/Field.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Content\CriterionVisitor;
 
 use Ibexa\Solr\Query\Common\CriterionVisitor\Field as FieldBase;

--- a/src/lib/Query/Content/CriterionVisitor/FullText.php
+++ b/src/lib/Query/Content/CriterionVisitor/FullText.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Content\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Content/CriterionVisitor/LocationIdIn.php
+++ b/src/lib/Query/Content/CriterionVisitor/LocationIdIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Content\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Content/CriterionVisitor/LocationRemoteIdIn.php
+++ b/src/lib/Query/Content/CriterionVisitor/LocationRemoteIdIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Content\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Content/CriterionVisitor/ParentLocationIdIn.php
+++ b/src/lib/Query/Content/CriterionVisitor/ParentLocationIdIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Content\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Content/CriterionVisitor/SubtreeIn.php
+++ b/src/lib/Query/Content/CriterionVisitor/SubtreeIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Content\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Content/CriterionVisitor/Visibility.php
+++ b/src/lib/Query/Content/CriterionVisitor/Visibility.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Content\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/FacetBuilderVisitor.php
+++ b/src/lib/Query/FacetBuilderVisitor.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\FacetBuilder;

--- a/src/lib/Query/FacetFieldVisitor.php
+++ b/src/lib/Query/FacetFieldVisitor.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\FacetBuilder;

--- a/src/lib/Query/Location/CriterionVisitor/Ancestor.php
+++ b/src/lib/Query/Location/CriterionVisitor/Ancestor.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Location\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Location/CriterionVisitor/FullText.php
+++ b/src/lib/Query/Location/CriterionVisitor/FullText.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Location\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Location/CriterionVisitor/Location/DepthBetween.php
+++ b/src/lib/Query/Location/CriterionVisitor/Location/DepthBetween.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Location\CriterionVisitor\Location;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Location/CriterionVisitor/Location/DepthIn.php
+++ b/src/lib/Query/Location/CriterionVisitor/Location/DepthIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Location\CriterionVisitor\Location;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Location/CriterionVisitor/Location/IsMainLocation.php
+++ b/src/lib/Query/Location/CriterionVisitor/Location/IsMainLocation.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Location\CriterionVisitor\Location;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Location/CriterionVisitor/Location/PriorityBetween.php
+++ b/src/lib/Query/Location/CriterionVisitor/Location/PriorityBetween.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Location\CriterionVisitor\Location;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Location/CriterionVisitor/Location/PriorityIn.php
+++ b/src/lib/Query/Location/CriterionVisitor/Location/PriorityIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Location\CriterionVisitor\Location;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Location/CriterionVisitor/LocationIdIn.php
+++ b/src/lib/Query/Location/CriterionVisitor/LocationIdIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Location\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Location/CriterionVisitor/LocationRemoteIdIn.php
+++ b/src/lib/Query/Location/CriterionVisitor/LocationRemoteIdIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Location\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Location/CriterionVisitor/ParentLocationIdIn.php
+++ b/src/lib/Query/Location/CriterionVisitor/ParentLocationIdIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Location\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Location/CriterionVisitor/SubtreeIn.php
+++ b/src/lib/Query/Location/CriterionVisitor/SubtreeIn.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Location\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Location/CriterionVisitor/Visibility.php
+++ b/src/lib/Query/Location/CriterionVisitor/Visibility.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Location\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;

--- a/src/lib/Query/Location/SortClauseVisitor/Location/Depth.php
+++ b/src/lib/Query/Location/SortClauseVisitor/Location/Depth.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Location\SortClauseVisitor\Location;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;

--- a/src/lib/Query/Location/SortClauseVisitor/Location/Id.php
+++ b/src/lib/Query/Location/SortClauseVisitor/Location/Id.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Location\SortClauseVisitor\Location;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;

--- a/src/lib/Query/Location/SortClauseVisitor/Location/IsMainLocation.php
+++ b/src/lib/Query/Location/SortClauseVisitor/Location/IsMainLocation.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Location\SortClauseVisitor\Location;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;

--- a/src/lib/Query/Location/SortClauseVisitor/Location/Path.php
+++ b/src/lib/Query/Location/SortClauseVisitor/Location/Path.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Location\SortClauseVisitor\Location;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;

--- a/src/lib/Query/Location/SortClauseVisitor/Location/Priority.php
+++ b/src/lib/Query/Location/SortClauseVisitor/Location/Priority.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Location\SortClauseVisitor\Location;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;

--- a/src/lib/Query/Location/SortClauseVisitor/Location/Visibility.php
+++ b/src/lib/Query/Location/SortClauseVisitor/Location/Visibility.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query\Location\SortClauseVisitor\Location;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;

--- a/src/lib/Query/QueryConverter.php
+++ b/src/lib/Query/QueryConverter.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\Query;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;

--- a/src/lib/ResultExtractor.php
+++ b/src/lib/ResultExtractor.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Spellcheck;

--- a/src/lib/ResultExtractor/LoadingResultExtractor.php
+++ b/src/lib/ResultExtractor/LoadingResultExtractor.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\ResultExtractor;
 
 use Ibexa\Contracts\Core\Persistence\Content\Handler as ContentHandler;

--- a/src/lib/ResultExtractor/NativeResultExtractor.php
+++ b/src/lib/ResultExtractor/NativeResultExtractor.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Solr\ResultExtractor;
 
 use Ibexa\Contracts\Core\Persistence\Content\ContentInfo;

--- a/tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
+++ b/tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Tests\Bundle\Solr\DependencyInjection;
 
 use Ibexa\Bundle\Solr\DependencyInjection\Configuration;

--- a/tests/lib/Container/Compiler/AggregateCriterionVisitorPassTest.php
+++ b/tests/lib/Container/Compiler/AggregateCriterionVisitorPassTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Tests\Solr\Container\Compiler;
 
 use Ibexa\Solr\Container\Compiler\AggregateCriterionVisitorPass;

--- a/tests/lib/Container/Compiler/AggregateFacetBuilderVisitorPassTest.php
+++ b/tests/lib/Container/Compiler/AggregateFacetBuilderVisitorPassTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Tests\Solr\Container\Compiler;
 
 use Ibexa\Solr\Container\Compiler\AggregateFacetBuilderVisitorPass;

--- a/tests/lib/Container/Compiler/AggregateSortClauseVisitorPassTest.php
+++ b/tests/lib/Container/Compiler/AggregateSortClauseVisitorPassTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Tests\Solr\Container\Compiler;
 
 use Ibexa\Solr\Container\Compiler\AggregateSortClauseVisitorPass;

--- a/tests/lib/Container/Compiler/CoreFilterRegistryPassTest.php
+++ b/tests/lib/Container/Compiler/CoreFilterRegistryPassTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Tests\Solr\Container\Compiler;
 
 use Ibexa\Solr\Container\Compiler\CoreFilterRegistryPass;

--- a/tests/lib/Container/Compiler/GatewayRegistryPassTest.php
+++ b/tests/lib/Container/Compiler/GatewayRegistryPassTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Tests\Solr\Container\Compiler;
 
 use Ibexa\Solr\Container\Compiler\GatewayRegistryPass;

--- a/tests/lib/CoreFilter/CoreFilterRegistryTest.php
+++ b/tests/lib/CoreFilter/CoreFilterRegistryTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Tests\Solr\CoreFilter;
 
 use Ibexa\Solr\CoreFilter;
@@ -21,7 +22,7 @@ class CoreFilterRegistryTest extends TestCase
         $registry = new CoreFilterRegistry();
         $registry->addCoreFilter('connection1', $this->getCoreFilterMock());
 
-        $this->assertCount(1, $registry->getCoreFilters());
+        self::assertCount(1, $registry->getCoreFilters());
     }
 
     /**
@@ -31,7 +32,7 @@ class CoreFilterRegistryTest extends TestCase
     {
         $registry = new CoreFilterRegistry(['connection1' => $this->getCoreFilterMock()]);
 
-        $this->assertInstanceOf(CoreFilter::class, $registry->getCoreFilter('connection1'));
+        self::assertInstanceOf(CoreFilter::class, $registry->getCoreFilter('connection1'));
     }
 
     /**
@@ -52,7 +53,7 @@ class CoreFilterRegistryTest extends TestCase
     {
         $registry = new CoreFilterRegistry(['connection1' => $this->getCoreFilterMock()]);
 
-        $this->assertTrue($registry->hasCoreFilter('connection1'));
+        self::assertTrue($registry->hasCoreFilter('connection1'));
     }
 
     /**
@@ -65,7 +66,7 @@ class CoreFilterRegistryTest extends TestCase
         $registry = new CoreFilterRegistry();
         $registry->setCoreFilters($coreFilters);
 
-        $this->assertEquals($coreFilters, $registry->getCoreFilters());
+        self::assertEquals($coreFilters, $registry->getCoreFilters());
     }
 
     /**
@@ -75,7 +76,7 @@ class CoreFilterRegistryTest extends TestCase
     {
         $registry = new CoreFilterRegistry(['connection1' => $this->getCoreFilterMock()]);
 
-        $this->assertCount(1, $registry->getCoreFilters());
+        self::assertCount(1, $registry->getCoreFilters());
     }
 
     /**

--- a/tests/lib/Gateway/GatewayRegistryTest.php
+++ b/tests/lib/Gateway/GatewayRegistryTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Tests\Solr\Gateway;
 
 use Ibexa\Solr\Gateway;
@@ -21,7 +22,7 @@ class GatewayRegistryTest extends TestCase
         $registry = new GatewayRegistry();
         $registry->addGateway('connection1', $this->getGatewayMock());
 
-        $this->assertCount(1, $registry->getGateways());
+        self::assertCount(1, $registry->getGateways());
     }
 
     /**
@@ -32,7 +33,7 @@ class GatewayRegistryTest extends TestCase
         $registry = new GatewayRegistry();
         $registry->addGateway('connection1', $this->getGatewayMock());
 
-        $this->assertInstanceOf(Gateway::class, $registry->getGateway('connection1'));
+        self::assertInstanceOf(Gateway::class, $registry->getGateway('connection1'));
     }
 
     /**
@@ -54,7 +55,7 @@ class GatewayRegistryTest extends TestCase
         $registry = new GatewayRegistry();
         $registry->addGateway('connection1', $this->getGatewayMock());
 
-        $this->assertTrue($registry->hasGateway('connection1'));
+        self::assertTrue($registry->hasGateway('connection1'));
     }
 
     /**
@@ -67,7 +68,7 @@ class GatewayRegistryTest extends TestCase
         $registry = new GatewayRegistry();
         $registry->setGateways($gateways);
 
-        $this->assertEquals($gateways, $registry->getGateways());
+        self::assertEquals($gateways, $registry->getGateways());
     }
 
     /**
@@ -77,7 +78,7 @@ class GatewayRegistryTest extends TestCase
     {
         $registry = new GatewayRegistry(['connection1' => $this->getGatewayMock()]);
 
-        $this->assertCount(1, $registry->getGateways());
+        self::assertCount(1, $registry->getGateways());
     }
 
     /**

--- a/tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
+++ b/tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Tests\Solr\Search\FieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content\Type as SPIContentType;
@@ -126,7 +127,7 @@ class BoostFactorProviderTest extends TestCase
             $this->getFieldDefinitionStub($fieldDefinitionIdentifier)
         );
 
-        $this->assertEquals($expectedBoostFactor, $boostFactor);
+        self::assertEquals($expectedBoostFactor, $boostFactor);
     }
 
     public function providerForTestGetContentMetaFieldBoostFactor()
@@ -252,7 +253,7 @@ class BoostFactorProviderTest extends TestCase
             $fieldName
         );
 
-        $this->assertEquals($expectedBoostFactor, $boostFactor);
+        self::assertEquals($expectedBoostFactor, $boostFactor);
     }
 
     protected function getFieldBoostProvider(array $map)

--- a/tests/lib/Search/FieldMapper/IndexingDepthProviderTest.php
+++ b/tests/lib/Search/FieldMapper/IndexingDepthProviderTest.php
@@ -18,11 +18,11 @@ class IndexingDepthProviderTest extends TestCase
     {
         $indexingDepthProvider = $this->createIndexingDepthProvider();
 
-        $this->assertEquals(2, $indexingDepthProvider->getMaxDepthForContent(
+        self::assertEquals(2, $indexingDepthProvider->getMaxDepthForContent(
             $this->getContentTypeStub('article')
         ));
 
-        $this->assertEquals(1, $indexingDepthProvider->getMaxDepthForContent(
+        self::assertEquals(1, $indexingDepthProvider->getMaxDepthForContent(
             $this->getContentTypeStub('blog_post')
         ));
     }
@@ -31,14 +31,14 @@ class IndexingDepthProviderTest extends TestCase
     {
         $indexingDepthProvider = $this->createIndexingDepthProvider();
 
-        $this->assertEquals(0, $indexingDepthProvider->getMaxDepthForContent(
+        self::assertEquals(0, $indexingDepthProvider->getMaxDepthForContent(
             $this->getContentTypeStub('folder')
         ));
     }
 
     public function testGetMaxDepth()
     {
-        $this->assertEquals(2, $this->createIndexingDepthProvider()->getMaxDepth());
+        self::assertEquals(2, $this->createIndexingDepthProvider()->getMaxDepth());
     }
 
     private function createIndexingDepthProvider(): IndexingDepthProvider

--- a/tests/lib/Search/Gateway/DistributionStrategy/CloudDistributionStrategyTest.php
+++ b/tests/lib/Search/Gateway/DistributionStrategy/CloudDistributionStrategyTest.php
@@ -47,7 +47,7 @@ class CloudDistributionStrategyTest extends TestCase
     public function testGetSearchParameters(): void
     {
         $this->endpointResolver
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getEndpoints')
             ->willReturn(['en', 'de', 'fr', 'pl']);
 
@@ -56,7 +56,7 @@ class CloudDistributionStrategyTest extends TestCase
             'indent' => true,
         ];
 
-        $this->assertEquals([
+        self::assertEquals([
             'wt' => 'json',
             'indent' => true,
             'collection' => 'collection_en,collection_de,collection_fr,collection_pl',
@@ -70,7 +70,7 @@ class CloudDistributionStrategyTest extends TestCase
         ];
 
         $this->endpointResolver
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getSearchTargets')
             ->with($languagesSettings)
             ->willReturn(['en', 'pl']);
@@ -80,7 +80,7 @@ class CloudDistributionStrategyTest extends TestCase
             'indent' => true,
         ];
 
-        $this->assertEquals([
+        self::assertEquals([
             'wt' => 'json',
             'indent' => true,
             'collection' => 'collection_en,collection_pl',

--- a/tests/lib/Search/Gateway/DistributionStrategy/StandaloneDistributionStrategyTest.php
+++ b/tests/lib/Search/Gateway/DistributionStrategy/StandaloneDistributionStrategyTest.php
@@ -40,7 +40,7 @@ class StandaloneDistributionStrategyTest extends TestCase
     public function testGetSearchTargets(): void
     {
         $this->endpointResolver
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getEndpoints')
             ->willReturn(['A', 'B', 'C']);
 
@@ -49,7 +49,7 @@ class StandaloneDistributionStrategyTest extends TestCase
             'indent' => true,
         ]);
 
-        $this->assertEquals([
+        self::assertEquals([
             'wt' => 'json',
             'indent' => true,
             'shards' => '127.0.0.65:8983/solr/collection1,127.0.0.66:8983/solr/collection1,127.0.0.67:8983/solr/collection1',
@@ -63,7 +63,7 @@ class StandaloneDistributionStrategyTest extends TestCase
         ];
 
         $this->endpointResolver
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getSearchTargets')
             ->with($languagesSettings)
             ->willReturn(['A', 'B']);
@@ -73,7 +73,7 @@ class StandaloneDistributionStrategyTest extends TestCase
             'indent' => true,
         ];
 
-        $this->assertEquals([
+        self::assertEquals([
             'wt' => 'json',
             'indent' => true,
             'shards' => '127.0.0.65:8983/solr/collection1,127.0.0.66:8983/solr/collection1',

--- a/tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
+++ b/tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Tests\Solr\Search\Gateway\EndpointResolver;
 
 use Ibexa\Solr\Gateway\EndpointResolver\NativeEndpointResolver;
@@ -26,7 +27,7 @@ class NativeEndpointResolverTest extends TestCase
 
         $endpointResolver = $this->getEndpointResolver($entryEndpoints);
 
-        $this->assertEquals(
+        self::assertEquals(
             'endpoint2',
             $endpointResolver->getEntryEndpoint()
         );
@@ -50,7 +51,7 @@ class NativeEndpointResolverTest extends TestCase
 
         $endpointResolver = $this->getEndpointResolver([], $endpointMap);
 
-        $this->assertEquals(
+        self::assertEquals(
             'endpoint3',
             $endpointResolver->getIndexingTarget('eng-GB')
         );
@@ -63,7 +64,7 @@ class NativeEndpointResolverTest extends TestCase
 
         $endpointResolver = $this->getEndpointResolver([], $endpointMap, $defaultEndpoint);
 
-        $this->assertEquals(
+        self::assertEquals(
             'endpoint4',
             $endpointResolver->getIndexingTarget('ger-DE')
         );
@@ -82,7 +83,7 @@ class NativeEndpointResolverTest extends TestCase
 
         $endpointResolver = $this->getEndpointResolver([], [], null, $mainLanguagesEndpoint);
 
-        $this->assertEquals(
+        self::assertEquals(
             'endpoint5',
             $endpointResolver->getMainLanguagesEndpoint()
         );
@@ -92,7 +93,7 @@ class NativeEndpointResolverTest extends TestCase
     {
         $endpointResolver = $this->getEndpointResolver();
 
-        $this->assertNull($endpointResolver->getMainLanguagesEndpoint());
+        self::assertNull($endpointResolver->getMainLanguagesEndpoint());
     }
 
     public function providerForTestGetSearchTargets()
@@ -822,10 +823,10 @@ class NativeEndpointResolverTest extends TestCase
 
         $actual = $endpointResolver->getSearchTargets($languageSettings);
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
 
         if ($endpointResolver instanceof SingleEndpointResolver) {
-            $this->assertEquals($expectedIsMultiple, $endpointResolver->hasMultipleEndpoints());
+            self::assertEquals($expectedIsMultiple, $endpointResolver->hasMultipleEndpoints());
         }
     }
 
@@ -940,7 +941,7 @@ class NativeEndpointResolverTest extends TestCase
         try {
             $endpointResolver->getSearchTargets($languageSettings);
         } catch (RuntimeException $e) {
-            $this->assertEquals($message, $e->getMessage());
+            self::assertEquals($message, $e->getMessage());
 
             throw $e;
         }
@@ -1033,7 +1034,7 @@ class NativeEndpointResolverTest extends TestCase
 
         $endpoints = $endpointResolver->getEndpoints();
 
-        $this->assertEquals($expected, $endpoints);
+        self::assertEquals($expected, $endpoints);
     }
 
     public function testGetEndpointsThrowsRuntimeException()

--- a/tests/lib/Search/Gateway/EndpointTest.php
+++ b/tests/lib/Search/Gateway/EndpointTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Tests\Solr\Search\Gateway;
 
 use Ibexa\Contracts\Core\Repository\Exceptions\PropertyNotFoundException;
@@ -28,7 +29,7 @@ class EndpointTest extends TestCase
                 'core' => 'core0',
         ]);
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     public function testEndpointDsnParsingWithoutUser()
@@ -44,7 +45,7 @@ class EndpointTest extends TestCase
                 'core' => 'core0',
         ]);
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     public function testEndpointDsnParsingWithFragment()
@@ -60,7 +61,7 @@ class EndpointTest extends TestCase
                 'core' => 'core1',
         ]);
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     public function testEndpointDsnParsingOverridesAllIfSet()
@@ -85,7 +86,7 @@ class EndpointTest extends TestCase
                 'core' => 'core1',
         ]);
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     public function testEndpointDsnParsingWithQuery()

--- a/tests/lib/Search/Query/Common/AggregationVisitor/AbstractAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/AbstractAggregationVisitorTest.php
@@ -42,7 +42,7 @@ abstract class AbstractAggregationVisitorTest extends TestCase
         array $languageFilter,
         bool $expectedValue
     ): void {
-        $this->assertEquals(
+        self::assertEquals(
             $expectedValue,
             $this->visitor->canVisit($aggregation, $languageFilter)
         );
@@ -70,7 +70,7 @@ abstract class AbstractAggregationVisitorTest extends TestCase
     ): void {
         $this->configureMocksForTestVisit($aggregation, $languageFilter, $expectedResult);
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedResult,
             $this->visitor->visit($this->dispatcherVisitor, $aggregation, $languageFilter)
         );

--- a/tests/lib/Search/Query/Common/AggregationVisitor/AggregationFieldResolver/SearchFieldAggregationFieldResolverTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/AggregationFieldResolver/SearchFieldAggregationFieldResolverTest.php
@@ -20,7 +20,7 @@ final class SearchFieldAggregationFieldResolverTest extends TestCase
 
         $aggregationFieldResolver = new SearchFieldAggregationFieldResolver('custom_field_id');
 
-        $this->assertEquals(
+        self::assertEquals(
             'custom_field_id',
             $aggregationFieldResolver->resolveTargetField($aggregation)
         );

--- a/tests/lib/Search/Query/Common/AggregationVisitor/DispatcherAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/DispatcherAggregationVisitorTest.php
@@ -37,7 +37,7 @@ final class DispatcherAggregationVisitorTest extends TestCase
             $this->createVisitorMock($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false),
         ]);
 
-        $this->assertTrue($dispatcher->canVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER));
+        self::assertTrue($dispatcher->canVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER));
     }
 
     public function testCanVisitOnNonSupportedAggregation(): void
@@ -50,7 +50,7 @@ final class DispatcherAggregationVisitorTest extends TestCase
             $this->createVisitorMock($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false),
         ]);
 
-        $this->assertFalse($dispatcher->canVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER));
+        self::assertFalse($dispatcher->canVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER));
     }
 
     public function testVisit(): void
@@ -68,7 +68,7 @@ final class DispatcherAggregationVisitorTest extends TestCase
             ->with($dispatcher, $aggregation, self::EXAMPLE_LANGUAGE_FILTER)
             ->willReturn(self::EXAMPLE_VISITOR_RESULT);
 
-        $this->assertEquals(
+        self::assertEquals(
             self::EXAMPLE_VISITOR_RESULT,
             $dispatcher->visit($dispatcher, $aggregation, self::EXAMPLE_LANGUAGE_FILTER)
         );

--- a/tests/lib/Search/Query/Common/AggregationVisitor/RangeAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/RangeAggregationVisitorTest.php
@@ -25,7 +25,7 @@ final class RangeAggregationVisitorTest extends AbstractAggregationVisitorTest
         $this->aggregationFieldResolver = $this->createMock(AggregationFieldResolver::class);
         $this->aggregationFieldResolver
             ->method('resolveTargetField')
-            ->with($this->isInstanceOf(AbstractRangeAggregation::class))
+            ->with(self::isInstanceOf(AbstractRangeAggregation::class))
             ->willReturn('custom_field_id');
 
         parent::setUp();

--- a/tests/lib/Search/Query/Common/AggregationVisitor/StatsAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/StatsAggregationVisitorTest.php
@@ -24,7 +24,7 @@ final class StatsAggregationVisitorTest extends AbstractAggregationVisitorTest
         $this->aggregationFieldResolver = $this->createMock(AggregationFieldResolver::class);
         $this->aggregationFieldResolver
             ->method('resolveTargetField')
-            ->with($this->isInstanceOf(AbstractStatsAggregation::class))
+            ->with(self::isInstanceOf(AbstractStatsAggregation::class))
             ->willReturn('custom_field_id');
 
         parent::setUp();

--- a/tests/lib/Search/Query/Common/AggregationVisitor/TermAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/TermAggregationVisitorTest.php
@@ -24,7 +24,7 @@ final class TermAggregationVisitorTest extends AbstractAggregationVisitorTest
         $this->aggregationFieldResolver = $this->createMock(AggregationFieldResolver::class);
         $this->aggregationFieldResolver
             ->method('resolveTargetField')
-            ->with($this->isInstanceOf(AbstractTermAggregation::class))
+            ->with(self::isInstanceOf(AbstractTermAggregation::class))
             ->willReturn('custom_field_id');
 
         parent::setUp();

--- a/tests/lib/Search/Query/Content/CriterionVisitor/FullTextTest.php
+++ b/tests/lib/Search/Query/Content/CriterionVisitor/FullTextTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Tests\Solr\Search\Query\Content\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
@@ -34,22 +35,22 @@ class FullTextTest extends TestCase
             ->getMock();
 
         $fieldNameResolver
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getFieldNames')
             ->with(
-                $this->isInstanceOf(Criterion::class),
-                $this->isType('string')
+                self::isInstanceOf(Criterion::class),
+                self::isType('string')
             )
             ->willReturn(
                 $fieldNames
             );
 
         $fieldNameResolver
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getFieldTypes')
             ->with(
-                $this->isInstanceOf(Criterion::class),
-                $this->isType('string')
+                self::isInstanceOf(Criterion::class),
+                self::isType('string')
             )
             ->willReturn(
                 $fieldTypes
@@ -113,7 +114,7 @@ class FullTextTest extends TestCase
 
         $criterion = new Criterion\FullText('Hello');
 
-        $this->assertEquals(
+        self::assertEquals(
             "{!edismax v='Hello' qf='meta_content__text_t' uf=-*}",
             $visitor->visit($criterion)
         );
@@ -125,7 +126,7 @@ class FullTextTest extends TestCase
 
         $criterion = new Criterion\FullText('Hello World');
 
-        $this->assertEquals(
+        self::assertEquals(
             "{!edismax v='Hello World' qf='meta_content__text_t' uf=-*}",
             $visitor->visit($criterion)
         );
@@ -138,7 +139,7 @@ class FullTextTest extends TestCase
         $criterion = new Criterion\FullText('Hello');
         $criterion->fuzziness = .5;
 
-        $this->assertEquals(
+        self::assertEquals(
             "{!edismax v='Hello~0.5' qf='meta_content__text_t' uf=-*}",
             $visitor->visit($criterion)
         );
@@ -151,7 +152,7 @@ class FullTextTest extends TestCase
         $criterion = new Criterion\FullText('Hello World');
         $criterion->fuzziness = .5;
 
-        $this->assertEquals(
+        self::assertEquals(
             "{!edismax v='Hello~0.5 World~0.5' qf='meta_content__text_t' uf=-*}",
             $visitor->visit($criterion)
         );
@@ -170,7 +171,7 @@ class FullTextTest extends TestCase
         $criterion = new Criterion\FullText('Hello');
         $criterion->boost = ['title' => 2];
 
-        $this->assertEquals(
+        self::assertEquals(
             "{!edismax v='Hello' qf='meta_content__text_t title_1_s^2 title_2_s^2' uf=-*}",
             $visitor->visit($criterion)
         );
@@ -189,7 +190,7 @@ class FullTextTest extends TestCase
         $criterion = new Criterion\FullText('Hello World');
         $criterion->boost = ['title' => 2];
 
-        $this->assertEquals(
+        self::assertEquals(
             "{!edismax v='Hello World' qf='meta_content__text_t title_1_s^2 title_2_s^2' uf=-*}",
             $visitor->visit($criterion)
         );
@@ -204,7 +205,7 @@ class FullTextTest extends TestCase
             'unknown_field' => 2,
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             "{!edismax v='Hello' qf='meta_content__text_t' uf=-*}",
             $visitor->visit($criterion)
         );
@@ -219,7 +220,7 @@ class FullTextTest extends TestCase
             'unknown_field' => 2,
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             "{!edismax v='Hello World' qf='meta_content__text_t' uf=-*}",
             $visitor->visit($criterion)
         );
@@ -238,7 +239,7 @@ class FullTextTest extends TestCase
         $criterion->fuzziness = .5;
         $criterion->boost = ['title' => 2];
 
-        $this->assertEquals(
+        self::assertEquals(
             "{!edismax v='Hello~0.5' qf='meta_content__text_t title_1_s^2 title_2_s^2' uf=-*}",
             $visitor->visit($criterion)
         );
@@ -257,7 +258,7 @@ class FullTextTest extends TestCase
         $criterion->fuzziness = .5;
         $criterion->boost = ['title' => 2];
 
-        $this->assertEquals(
+        self::assertEquals(
             "{!edismax v='Hello~0.5 World~0.5' qf='meta_content__text_t title_1_s^2 title_2_s^2' uf=-*}",
             $visitor->visit($criterion)
         );
@@ -269,7 +270,7 @@ class FullTextTest extends TestCase
 
         $criterion = new Criterion\FullText('OR Hello && (and goodbye)) AND OR AND "as NOT +always');
 
-        $this->assertEquals(
+        self::assertEquals(
             "{!edismax v='Hello AND (and goodbye) as +always' qf='meta_content__text_t' uf=-*}",
             $visitor->visit($criterion)
         );
@@ -281,7 +282,7 @@ class FullTextTest extends TestCase
 
         $criterion = new Criterion\FullText('Hello');
 
-        $this->assertEquals(
+        self::assertEquals(
             "{!edismax v='Hello' qf='meta_content__text_t meta_related_content_1__text_t^0.5 meta_related_content_2__text_t^0.25 meta_related_content_3__text_t^0.125' uf=-*}",
             $visitor->visit($criterion)
         );

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/AbstractAggregationResultExtractorTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/AbstractAggregationResultExtractorTest.php
@@ -37,7 +37,7 @@ abstract class AbstractAggregationResultExtractorTest extends TestCase
         array $languageFilter,
         bool $expectedResult
     ): void {
-        $this->assertEquals(
+        self::assertEquals(
             $expectedResult,
             $this->extractor->canVisit($aggregation, $languageFilter)
         );
@@ -54,7 +54,7 @@ abstract class AbstractAggregationResultExtractorTest extends TestCase
         stdClass $rawData,
         AggregationResult $expectedResult
     ): void {
-        $this->assertEquals(
+        self::assertEquals(
             $expectedResult,
             $this->extractor->extract($aggregation, $languageFilter, $rawData)
         );

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/DispatcherAggregationResultExtractorTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/DispatcherAggregationResultExtractorTest.php
@@ -30,7 +30,7 @@ final class DispatcherAggregationResultExtractorTest extends TestCase
             $this->createExtractorMockWithCanVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false),
         ]);
 
-        $this->assertTrue($dispatcher->canVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER));
+        self::assertTrue($dispatcher->canVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER));
     }
 
     public function testSupportsReturnsFalse(): void
@@ -43,7 +43,7 @@ final class DispatcherAggregationResultExtractorTest extends TestCase
             $this->createExtractorMockWithCanVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false),
         ]);
 
-        $this->assertFalse($dispatcher->canVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER));
+        self::assertFalse($dispatcher->canVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER));
     }
 
     public function testExtract(): void
@@ -64,7 +64,7 @@ final class DispatcherAggregationResultExtractorTest extends TestCase
             ->with($aggregation, self::EXAMPLE_LANGUAGE_FILTER, $data)
             ->willReturn($expectedResult);
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedResult,
             $dispatcher->extract($aggregation, self::EXAMPLE_LANGUAGE_FILTER, $data)
         );

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/NestedAggregationResultExtractorTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/NestedAggregationResultExtractorTest.php
@@ -39,12 +39,12 @@ final class NestedAggregationResultExtractorTest extends TestCase
         $aggregation = $this->createMock(Aggregation::class);
 
         $this->innerResultExtractor
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('canVisit')
             ->with($aggregation, AggregationResultExtractorTestUtils::EXAMPLE_LANGUAGE_FILTER)
             ->willReturn(true);
 
-        $this->assertTrue(
+        self::assertTrue(
             $this->resultExtractor->canVisit(
                 $aggregation,
                 AggregationResultExtractorTestUtils::EXAMPLE_LANGUAGE_FILTER
@@ -62,7 +62,7 @@ final class NestedAggregationResultExtractorTest extends TestCase
         $aggregation = $this->createMock(Aggregation::class);
 
         $this->innerResultExtractor
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('extract')
             ->with(
                 $aggregation,
@@ -74,7 +74,7 @@ final class NestedAggregationResultExtractorTest extends TestCase
         $wrappedData = new stdClass();
         $wrappedData->{self::EXAMPLE_NESTED_RESULT_KEY} = $data;
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedResult,
             $this->resultExtractor->extract(
                 $aggregation,

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/AbstractRangeAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/AbstractRangeAggregationKeyMapperTest.php
@@ -23,7 +23,7 @@ abstract class AbstractRangeAggregationKeyMapperTest extends TestCase
     {
         $mapper = $this->createRangeAggregationKeyMapper();
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedResult,
             $mapper->map($aggregation, $languageFilter, $key)
         );

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/AuthorAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/AuthorAggregationKeyMapperTest.php
@@ -28,7 +28,7 @@ final class AuthorAggregationKeyMapperTest extends TestCase
     ): void {
         $mapper = new AuthorAggregationKeyMapper();
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedResult,
             $mapper->map(
                 $aggregation,

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/BooleanAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/BooleanAggregationKeyMapperTest.php
@@ -19,7 +19,7 @@ final class BooleanAggregationKeyMapperTest extends TestCase
     {
         $mapper = new BooleanAggregationKeyMapper();
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 false => false,
                 true => true,

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeAggregationKeyMapperTest.php
@@ -38,7 +38,7 @@ final class ContentTypeAggregationKeyMapperTest extends TestCase
 
         $mapper = new ContentTypeAggregationKeyMapper($this->contentTypeService);
 
-        $this->assertEquals(
+        self::assertEquals(
             array_combine(
                 self::EXAMPLE_CONTENT_TYPE_IDS,
                 $expectedContentTypes

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeGroupAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeGroupAggregationKeyMapperTest.php
@@ -33,7 +33,7 @@ final class ContentTypeGroupAggregationKeyMapperTest extends TestCase
 
         $mapper = new ContentTypeGroupAggregationKeyMapper($this->contentTypeService);
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedContentTypesGroups,
             $mapper->map(
                 $this->createMock(Aggregation::class),
@@ -59,7 +59,7 @@ final class ContentTypeGroupAggregationKeyMapperTest extends TestCase
             $contentTypeGroup = $this->createContentTypeGroupWithIds((int)$id);
 
             $this->contentTypeService
-                ->expects($this->at($i))
+                ->expects(self::at($i))
                 ->method('loadContentTypeGroup')
                 ->with((int)$id, [])
                 ->willReturn($contentTypeGroup);

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/CountryAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/CountryAggregationKeyMapperTest.php
@@ -53,7 +53,7 @@ final class CountryAggregationKeyMapperTest extends TestCase
     ): void {
         $mapper = new CountryAggregationKeyMapper(self::EXAMPLE_COUNTRIES_INFO);
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedResult,
             $mapper->map(
                 $aggregation,

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/InvertedBooleanAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/InvertedBooleanAggregationKeyMapperTest.php
@@ -19,7 +19,7 @@ final class InvertedBooleanAggregationKeyMapperTest extends TestCase
     {
         $mapper = new InvertedBooleanAggregationKeyMapper();
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 false => true,
                 true => false,

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LanguageAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LanguageAggregationKeyMapperTest.php
@@ -40,7 +40,7 @@ final class LanguageAggregationKeyMapperTest extends TestCase
             ->with(self::EXAMPLE_LANGUAGE_CODES)
             ->willReturn($expectedLanguages);
 
-        $this->assertEquals(
+        self::assertEquals(
             array_combine(
                 self::EXAMPLE_LANGUAGE_CODES,
                 $expectedLanguages

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LocationAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LocationAggregationKeyMapperTest.php
@@ -40,7 +40,7 @@ final class LocationAggregationKeyMapperTest extends TestCase
             ->with(self::EXAMPLE_LOCATION_IDS)
             ->willReturn($expectedLocations);
 
-        $this->assertEquals(
+        self::assertEquals(
             array_combine(
                 self::EXAMPLE_LOCATION_IDS,
                 $expectedLocations

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/NullAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/NullAggregationKeyMapperTest.php
@@ -19,7 +19,7 @@ final class NullAggregationKeyMapperTest extends TestCase
     {
         $mapper = new NullAggregationKeyMapper();
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'foo' => 'foo',
                 'bar' => 'bar',

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ObjectStateAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ObjectStateAggregationKeyMapperTest.php
@@ -37,7 +37,7 @@ final class ObjectStateAggregationKeyMapperTest extends TestCase
             $this->configureObjectStateService('ez_lock', ['unlocked', 'locked'])
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedObjectStates,
             $this->mapper->map(
                 new ObjectStateTermAggregation('aggregation', 'ez_lock'),
@@ -63,7 +63,7 @@ final class ObjectStateAggregationKeyMapperTest extends TestCase
             $objectState = $this->createMock(ObjectState::class);
 
             $this->objectStateService
-                ->expects($this->at($i + 1))
+                ->expects(self::at($i + 1))
                 ->method('loadObjectStateByIdentifier')
                 ->with($objectStateGroup, $objectStateIdentifier, [])
                 ->willReturn($objectState);

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SectionAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SectionAggregationKeyMapperTest.php
@@ -35,7 +35,7 @@ final class SectionAggregationKeyMapperTest extends TestCase
     {
         $expectedSections = $this->configureSectionServiceMock(self::EXAMPLE_SECTION_IDS);
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedSections,
             $this->mapper->map(
                 $this->createMock(Aggregation::class),
@@ -52,7 +52,7 @@ final class SectionAggregationKeyMapperTest extends TestCase
             $section = $this->createMock(Section::class);
 
             $this->sectionService
-                ->expects($this->at($i))
+                ->expects(self::at($i))
                 ->method('loadSection')
                 ->with($sectionId)
                 ->willReturn($section);

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SubtreeAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SubtreeAggregationKeyMapperTest.php
@@ -43,7 +43,7 @@ final class SubtreeAggregationKeyMapperTest extends TestCase
 
         $mapper = new SubtreeAggregationKeyMapper($this->locationAggregationKeyMapper);
 
-        $this->assertEquals(
+        self::assertEquals(
             $exceptedResult,
             $mapper->map(
                 $aggregation,

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/UserMetadataAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/UserMetadataAggregationKeyMapperTest.php
@@ -39,7 +39,7 @@ final class UserMetadataAggregationKeyMapperTest extends TestCase
      */
     public function testMapForUserKey(Aggregation $aggregation): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             $this->createExpectedResultForUserKey(self::EXAMPLE_USER_IDS),
             $this->mapper->map(
                 $aggregation,
@@ -64,7 +64,7 @@ final class UserMetadataAggregationKeyMapperTest extends TestCase
     {
         $aggregation = new UserMetadataTermAggregation('group', UserMetadataTermAggregation::GROUP);
 
-        $this->assertEquals(
+        self::assertEquals(
             $this->createExpectedResultForUserGroupKey(self::EXAMPLE_USER_GROUP_IDS),
             $this->mapper->map(
                 $aggregation,
@@ -81,7 +81,7 @@ final class UserMetadataAggregationKeyMapperTest extends TestCase
             $user = $this->createMock(User::class);
 
             $this->userService
-                ->expects($this->at($i))
+                ->expects(self::at($i))
                 ->method('loadUser')
                 ->with($userId)
                 ->willReturn($user);
@@ -99,7 +99,7 @@ final class UserMetadataAggregationKeyMapperTest extends TestCase
             $user = $this->createMock(UserGroup::class);
 
             $this->userService
-                ->expects($this->at($i))
+                ->expects(self::at($i))
                 ->method('loadUserGroup')
                 ->with($userGroupId)
                 ->willReturn($user);

--- a/tests/lib/Search/TestCase.php
+++ b/tests/lib/Search/TestCase.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Tests\Solr\Search;
 
 use PHPUnit\Framework\TestCase as BaseTestCase;

--- a/tests/lib/SetupFactory/LegacySetupFactory.php
+++ b/tests/lib/SetupFactory/LegacySetupFactory.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Tests\Solr\SetupFactory;
 
 use Doctrine\DBAL\Connection;


### PR DESCRIPTION
| :ticket: Issue | IBX-8119 |
|----------------|-----------|

#### Description:

This PR bumps the minimum required version of PHP to 8.3.
`>=8.3` version constraint is set with expectation of compatibility with version PHP 9.

Additionally, this PR:
 * enforces sorting of packages within `require` and `require-dev` sections of composer.json file
 * replaces `~5.0.0@dev` declarations with their more development friendly `~5.0.x-dev`.
 * adjusts github workflows to match new PHP version
 * updates GH action versions
