### PR TITLE
Fixed deprecated namespaces usage

### DIFF
--- a/doc/specifications/document_field_mappers.md
+++ b/doc/specifications/document_field_mappers.md
@@ -66,27 +66,27 @@ something like this:
 
 namespace My\WebinarApp;
 
-use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper;
-use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
-use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
-use eZ\Publish\SPI\Persistence\Content;
-use eZ\Publish\SPI\Search;
+use Ibexa\Contracts\Solr\FieldMapper\ContentFieldMapper;
+use Ibexa\Contracts\Core\Persistence\Content\Handler as ContentHandler;
+use Ibexa\Contracts\Core\Persistence\Content\Location\Handler as LocationHandler;
+use Ibexa\Contracts\Core\Persistence\Content;
+use Ibexa\Contracts\Core\Search;
 
 class WebinarEventTitleFulltextFieldMapper extends ContentFieldMapper
 {
     /**
-     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
+     * @var \Ibexa\Contracts\Core\Persistence\Content\Handler
      */
     protected $contentHandler;
 
     /**
-     * @var \eZ\Publish\SPI\Persistence\Content\Location\Handler
+     * @var \Ibexa\Contracts\Core\Persistence\Content\Location\Handler
      */
     protected $locationHandler;
 
     /**
-     * @param \eZ\Publish\SPI\Persistence\Content\Handler $contentHandler
-     * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $locationHandler
+     * @param \Ibexa\Contracts\Core\Persistence\Content\Handler $contentHandler
+     * @param \Ibexa\Contracts\Core\Persistence\Content\Location\Handler $locationHandler
      */
     public function __construct(
         ContentHandler $contentHandler,
@@ -127,8 +127,8 @@ this:
 my_webinar_app.webinar_event_title_fulltext_field_mapper:
     class: My\WebinarApp\WebinarEventTitleFulltextFieldMapper
     arguments:
-        - '@ezpublish.spi.persistence.content_handler'
-        - '@ezpublish.spi.persistence.location_handler'
+        $contentHandler: '@Ibexa\Contracts\Core\Persistence\Content\Handler'
+        $locationHandler: '@Ibexa\Contracts\Core\Persistence\Content\Location\Handler'
     tags:
         - {name: ibexa.search.solr.field.mapper.content}
 ```

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -1,7 +1,7 @@
 parameters:
     ibexa.solr.default_connection: ~
-    ibexa.solr.http_client.timeout: !php/const \EzSystems\EzPlatformSolrSearchEngineBundle\DependencyInjection\Configuration::SOLR_HTTP_CLIENT_DEFAULT_TIMEOUT
-    ibexa.solr.http_client.max_retries: !php/const \EzSystems\EzPlatformSolrSearchEngineBundle\DependencyInjection\Configuration::SOLR_HTTP_CLIENT_DEFAULT_MAX_RETRIES
+    ibexa.solr.http_client.timeout: !php/const \Ibexa\Bundle\Solr\DependencyInjection\Configuration::SOLR_HTTP_CLIENT_DEFAULT_TIMEOUT
+    ibexa.solr.http_client.max_retries: !php/const \Ibexa\Bundle\Solr\DependencyInjection\Configuration::SOLR_HTTP_CLIENT_DEFAULT_MAX_RETRIES
 
 services:
     ibexa.solr.http_client.retryable:

--- a/src/lib/Gateway/HttpClient/Stream.php
+++ b/src/lib/Gateway/HttpClient/Stream.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * Simple PHP stream based HTTP client.
  *
- * @internal type-hint {@see \EzSystems\EzPlatformSolrSearchEngine\Gateway\HttpClient} instead.
+ * @internal type-hint {@see \Ibexa\Solr\Gateway\HttpClient} instead.
  */
 class Stream implements HttpClient, LoggerAwareInterface
 {


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|

#### Description:
Found usages of 2 constants from EzSystems namespace. Blocks #68 and regression build. Additionally fixed some doc example that should probably be moved to the official doc later.

#### For QA:

No QA required, CI should be enough as the change is covered via tests.



