### PR TITLE
IBX-8394: Used new RepositoryConfigurationProviderInterface contract

### DIFF
--- a/src/bundle/ApiLoader/BoostFactorProviderFactory.php
+++ b/src/bundle/ApiLoader/BoostFactorProviderFactory.php
@@ -20,10 +20,7 @@ class BoostFactorProviderFactory implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface
-     */
-    private $repositoryConfigurationProvider;
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
     /**
      * @var string

--- a/src/bundle/ApiLoader/BoostFactorProviderFactory.php
+++ b/src/bundle/ApiLoader/BoostFactorProviderFactory.php
@@ -7,7 +7,7 @@
 
 namespace Ibexa\Bundle\Solr\ApiLoader;
 
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Solr\FieldMapper\BoostFactorProvider;
 use LogicException;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
@@ -21,7 +21,7 @@ class BoostFactorProviderFactory implements ContainerAwareInterface
     use ContainerAwareTrait;
 
     /**
-     * @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider
+     * @var \Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface
      */
     private $repositoryConfigurationProvider;
 
@@ -40,7 +40,7 @@ class BoostFactorProviderFactory implements ContainerAwareInterface
      * @param string $boostFactorProviderClass
      */
     public function __construct(
-        RepositoryConfigurationProvider $repositoryConfigurationProvider,
+        RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
         $defaultConnection,
         $boostFactorProviderClass
     ) {

--- a/src/bundle/ApiLoader/IndexingDepthProviderFactory.php
+++ b/src/bundle/ApiLoader/IndexingDepthProviderFactory.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\Solr\ApiLoader;
 
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Solr\FieldMapper\IndexingDepthProvider;
 use LogicException;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
@@ -19,7 +19,7 @@ class IndexingDepthProviderFactory implements ContainerAwareInterface
     use ContainerAwareTrait;
 
     /**
-     * @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider
+     * @var \Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface
      */
     private $repositoryConfigurationProvider;
 
@@ -34,7 +34,7 @@ class IndexingDepthProviderFactory implements ContainerAwareInterface
     private $indexingDepthProviderClass;
 
     public function __construct(
-        RepositoryConfigurationProvider $repositoryConfigurationProvider,
+        RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
         string $defaultConnection,
         string $indexingDepthProviderClass
     ) {

--- a/src/bundle/ApiLoader/IndexingDepthProviderFactory.php
+++ b/src/bundle/ApiLoader/IndexingDepthProviderFactory.php
@@ -18,10 +18,7 @@ class IndexingDepthProviderFactory implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface
-     */
-    private $repositoryConfigurationProvider;
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
     /**
      * @var string

--- a/src/bundle/ApiLoader/SolrEngineFactory.php
+++ b/src/bundle/ApiLoader/SolrEngineFactory.php
@@ -16,8 +16,7 @@ use Ibexa\Solr\ResultExtractor;
 
 class SolrEngineFactory
 {
-    /** @var \Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface */
-    private $repositoryConfigurationProvider;
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
     /** @var string */
     private $defaultConnection;

--- a/src/bundle/ApiLoader/SolrEngineFactory.php
+++ b/src/bundle/ApiLoader/SolrEngineFactory.php
@@ -7,7 +7,7 @@
 
 namespace Ibexa\Bundle\Solr\ApiLoader;
 
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Contracts\Core\Persistence\Content\Handler;
 use Ibexa\Contracts\Solr\DocumentMapper;
 use Ibexa\Solr\CoreFilter\CoreFilterRegistry;
@@ -16,7 +16,7 @@ use Ibexa\Solr\ResultExtractor;
 
 class SolrEngineFactory
 {
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
+    /** @var \Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface */
     private $repositoryConfigurationProvider;
 
     /** @var string */
@@ -44,7 +44,7 @@ class SolrEngineFactory
     private $locationResultExtractor;
 
     public function __construct(
-        RepositoryConfigurationProvider $repositoryConfigurationProvider,
+        RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
         $defaultConnection,
         $searchEngineClass,
         GatewayRegistry $gatewayRegistry,


### PR DESCRIPTION
| :ticket: Issue | IBX-8394 |
|----------------|-----------|

#### Description:

Replaced usages of `\Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider`
with `\Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface`, using ibexa/rector#6.

#### For QA:

No QA needed. Regression tests should be enough.

#### Documentation:

This is code refactoring without behavior change. No documentation changes needed.
