### PR TITLE
Fix backup extension when modifying solrconfig.xml

### DIFF
--- a/.github/init_solr.sh
+++ b/.github/init_solr.sh
@@ -234,7 +234,7 @@ solr_cloud_configure_collection() {
     # Adapt autoSoftCommit to have a recommended value
     sed -i.bak 's/${solr.autoSoftCommit.maxTime:-1}/${solr.autoSoftCommit.maxTime:20}/' "${TEMPLATE_DIR}/solrconfig.xml" || exit_on_error "Can't modify file '${TEMPLATE_DIR}/solrconfig.xml'"
     # Configure spellcheck component
-    sed -i.bar 's/<str name="field">_text_<\/str>/<str name="field">meta_content__text_t<\/str>/' "${TEMPLATE_DIR}/solrconfig.xml"
+    sed -i.bak 's/<str name="field">_text_<\/str>/<str name="field">meta_content__text_t<\/str>/' "${TEMPLATE_DIR}/solrconfig.xml"
     # Add spellcheck component to /select handler
     sed -i.bak 's/<requestHandler name="\/select" class="solr.SearchHandler">/<requestHandler name="\/select" class="solr.SearchHandler">\n    <arr name="last-components">\n      <str>spellcheck<\/str>\n    <\/arr>/' "${TEMPLATE_DIR}/solrconfig.xml"
 }

--- a/bin/generate-solr-config.sh
+++ b/bin/generate-solr-config.sh
@@ -122,7 +122,7 @@ fi
 sed -i.bak '/<updateRequestProcessorChain name="add-unknown-fields-to-the-schema".*/,/<\/updateRequestProcessorChain>/d' $DESTINATION_DIR/solrconfig.xml
 sed -i.bak 's/${solr.autoSoftCommit.maxTime:-1}/${solr.autoSoftCommit.maxTime:20}/' $DESTINATION_DIR/solrconfig.xml
 # Configure spellcheck component
-sed -i.bar 's/<str name="field">_text_<\/str>/<str name="field">meta_content__text_t<\/str>/' $DESTINATION_DIR/solrconfig.xml
+sed -i.bak 's/<str name="field">_text_<\/str>/<str name="field">meta_content__text_t<\/str>/' $DESTINATION_DIR/solrconfig.xml
 # Add spellcheck component to /select handler
 sed -i.bak 's/<requestHandler name="\/select" class="solr.SearchHandler">/<requestHandler name="\/select" class="solr.SearchHandler">\n    <arr name="last-components">\n      <str>spellcheck<\/str>\n    <\/arr>/' $DESTINATION_DIR/solrconfig.xml
 


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

#### Related PRs: 

- #52

#### Description:

A `solrconfig.xml.bar` appears in 4.6.10 that wasn't there on 4.5.7
This is due to a typo in backup file extension in `sed`, only `.bak` files are removed while cleaning up afterward.

#### For QA:

It doesn't change anything about Solr config, it just avoids to have unnecessary `solrconfig.xml.bar` file in the generated config.

#### Documentation:

N/A
