### PR TITLE
IBX-9121: Added support for IsUserEnabled criterion

### DIFF
--- a/src/lib/FieldMapper/ContentFieldMapper/UserDocumentFields.php
+++ b/src/lib/FieldMapper/ContentFieldMapper/UserDocumentFields.php
@@ -48,6 +48,14 @@ final class UserDocumentFields extends ContentFieldMapper
             );
         }
 
+        if (isset($userField->value->externalData['enabled'])) {
+            $fields[] = new Field(
+                'user_is_enabled',
+                $userField->value->externalData['enabled'],
+                new FieldType\BooleanField()
+            );
+        }
+
         return $fields;
     }
 

--- a/src/lib/Query/Common/CriterionVisitor/IsUserEnabled.php
+++ b/src/lib/Query/Common/CriterionVisitor/IsUserEnabled.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Solr\Query\Common\CriterionVisitor;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Solr\Query\CriterionVisitor;
+
+final class IsUserEnabled extends CriterionVisitor
+{
+    private const SEARCH_FIELD = 'user_is_enabled_b';
+
+    public function canVisit(Criterion $criterion): bool
+    {
+        return $criterion instanceof Criterion\IsUserEnabled;
+    }
+
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null): string
+    {
+        $value = $criterion->value;
+        if (!is_array($value) || !is_bool($value[0])) {
+            throw new \LogicException(
+                sprintf(
+                    '%s value should be of type array<bool>, received %s.',
+                    Criterion\IsUserEnabled::class,
+                    get_debug_type($value),
+                )
+            );
+        }
+
+        return self::SEARCH_FIELD . ':' . $this->toString($value[0]);
+    }
+}

--- a/src/lib/Resources/config/container/solr/criterion_visitors.yml
+++ b/src/lib/Resources/config/container/solr/criterion_visitors.yml
@@ -348,3 +348,7 @@ services:
         tags:
             - { name: ibexa.search.solr.query.content.criterion.visitor }
             - { name: ibexa.search.solr.query.location.criterion.visitor }
+
+    Ibexa\Solr\Query\Common\CriterionVisitor\IsUserEnabled:
+        tags:
+            - { name: ibexa.search.solr.query.content.criterion.visitor }

--- a/tests/lib/Search/Query/BaseCriterionVisitorTestCase.php
+++ b/tests/lib/Search/Query/BaseCriterionVisitorTestCase.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Solr\Search\Query;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Solr\Query\CriterionVisitor;
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseCriterionVisitorTestCase extends TestCase
+{
+    abstract protected function getVisitor(): CriterionVisitor;
+
+    abstract protected function getSupportedCriterion(): Criterion;
+
+    /**
+     * @return iterable<array{
+     *     string,
+     *     \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion
+     * }>
+     */
+    abstract protected function provideDataForTestVisit(): iterable;
+
+    /**
+     * @dataProvider provideDataForTestCanVisit
+     */
+    public function testCanVisit(
+        bool $expected,
+        Criterion $criterion
+    ): void {
+        self::assertSame(
+            $expected,
+            $this->getVisitor()->canVisit($criterion)
+        );
+    }
+
+    /**
+     * @return iterable<array{
+     *     bool,
+     *     \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion
+     * }>
+     */
+    public function provideDataForTestCanVisit(): iterable
+    {
+        yield 'Not supported criterion' => [
+            false,
+            new Criterion\ContentId(123),
+        ];
+
+        yield 'Supported criterion' => [
+            true,
+            $this->getSupportedCriterion(),
+        ];
+    }
+
+    /**
+     * @dataProvider provideDataForTestVisit
+     */
+    public function testVisit(
+        string $expectedQuery,
+        Criterion $criterion
+    ): void {
+        self::assertSame(
+            $expectedQuery,
+            $this->getVisitor()->visit($criterion)
+        );
+    }
+}

--- a/tests/lib/Search/Query/BaseCriterionVisitorTestCase.php
+++ b/tests/lib/Search/Query/BaseCriterionVisitorTestCase.php
@@ -10,6 +10,7 @@ namespace Ibexa\Tests\Solr\Search\Query;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 use Ibexa\Contracts\Solr\Query\CriterionVisitor;
+use Ibexa\Tests\Solr\Search\Query\Utils\Stub\TestCriterion;
 use PHPUnit\Framework\TestCase;
 
 abstract class BaseCriterionVisitorTestCase extends TestCase
@@ -49,7 +50,7 @@ abstract class BaseCriterionVisitorTestCase extends TestCase
     {
         yield 'Not supported criterion' => [
             false,
-            new Criterion\ContentId(123),
+            new TestCriterion(),
         ];
 
         yield 'Supported criterion' => [

--- a/tests/lib/Search/Query/Common/CriterionVisitor/IsUserEnabledTest.php
+++ b/tests/lib/Search/Query/Common/CriterionVisitor/IsUserEnabledTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Solr\Search\Query\Common\CriterionVisitor;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Solr\Query\CriterionVisitor;
+use Ibexa\Solr\Query\Common\CriterionVisitor\IsUserEnabled;
+use Ibexa\Tests\Solr\Search\Query\BaseCriterionVisitorTestCase;
+
+/**
+ * @covers \Ibexa\Solr\Query\Common\CriterionVisitor\IsUserEnabled
+ */
+final class IsUserEnabledTest extends BaseCriterionVisitorTestCase
+{
+    private CriterionVisitor $criterionVisitor;
+
+    protected function setUp(): void
+    {
+        $this->criterionVisitor = new IsUserEnabled();
+    }
+
+    protected function getVisitor(): CriterionVisitor
+    {
+        return $this->criterionVisitor;
+    }
+
+    protected function getSupportedCriterion(): Criterion
+    {
+        return new Criterion\IsUserEnabled();
+    }
+
+    protected function provideDataForTestVisit(): iterable
+    {
+        yield 'Query for enabled user' => [
+            'user_is_enabled_b:true',
+            new Criterion\IsUserEnabled(),
+        ];
+
+        yield 'Query for disabled user' => [
+            'user_is_enabled_b:false',
+            new Criterion\IsUserEnabled(false),
+        ];
+    }
+}

--- a/tests/lib/Search/Query/Location/CriterionVisitor/Location/IsBookmarkedTest.php
+++ b/tests/lib/Search/Query/Location/CriterionVisitor/Location/IsBookmarkedTest.php
@@ -13,12 +13,12 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 use Ibexa\Contracts\Solr\Query\CriterionVisitor;
 use Ibexa\Core\Repository\Values\User\UserReference;
 use Ibexa\Solr\Query\Location\CriterionVisitor\Location\IsBookmarked;
-use PHPUnit\Framework\TestCase;
+use Ibexa\Tests\Solr\Search\Query\BaseCriterionVisitorTestCase;
 
 /**
  * @covers \Ibexa\Solr\Query\Location\CriterionVisitor\Location\IsBookmarked
  */
-final class IsBookmarkedTest extends TestCase
+final class IsBookmarkedTest extends BaseCriterionVisitorTestCase
 {
     private const USER_ID = 123;
 
@@ -34,48 +34,16 @@ final class IsBookmarkedTest extends TestCase
     }
 
     /**
-     * @dataProvider provideDataForTestCanVisit
-     */
-    public function testCanVisit(
-        bool $expected,
-        Criterion $criterion
-    ): void {
-        self::assertSame(
-            $expected,
-            $this->visitor->canVisit($criterion)
-        );
-    }
-
-    /**
-     * @return iterable<array{
-     *     bool,
-     *     \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion
-     * }>
-     */
-    public function provideDataForTestCanVisit(): iterable
-    {
-        yield 'Not supported criterion' => [
-            false,
-            new Criterion\ContentId(123),
-        ];
-
-        yield 'Supported criterion' => [
-            true,
-            new Criterion\Location\IsBookmarked(),
-        ];
-    }
-
-    /**
      * @dataProvider provideDataForTestVisit
      */
     public function testVisit(
-        string $expected,
+        string $expectedQuery,
         Criterion $criterion
     ): void {
         $this->mockPermissionResolverGetCurrentUserReference();
 
         self::assertSame(
-            $expected,
+            $expectedQuery,
             $this->visitor->visit($criterion)
         );
     }
@@ -104,5 +72,15 @@ final class IsBookmarkedTest extends TestCase
         $this->permissionResolver
             ->method('getCurrentUserReference')
             ->willReturn(new UserReference(self::USER_ID));
+    }
+
+    protected function getVisitor(): CriterionVisitor
+    {
+        return $this->visitor;
+    }
+
+    protected function getSupportedCriterion(): Criterion
+    {
+        return new Criterion\Location\IsBookmarked();
     }
 }

--- a/tests/lib/Search/Query/Utils/Stub/TestCriterion.php
+++ b/tests/lib/Search/Query/Utils/Stub/TestCriterion.php
@@ -14,6 +14,7 @@ final class TestCriterion extends Criterion
 {
     public function __construct()
     {
+        // No implementation needed. Used for test purposes only.
     }
 
     public function getSpecifications(): array

--- a/tests/lib/Search/Query/Utils/Stub/TestCriterion.php
+++ b/tests/lib/Search/Query/Utils/Stub/TestCriterion.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Solr\Search\Query\Utils\Stub;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+
+final class TestCriterion extends Criterion
+{
+    public function __construct() {}
+
+    public function getSpecifications(): array
+    {
+        return [];
+    }
+}

--- a/tests/lib/Search/Query/Utils/Stub/TestCriterion.php
+++ b/tests/lib/Search/Query/Utils/Stub/TestCriterion.php
@@ -12,7 +12,9 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 
 final class TestCriterion extends Criterion
 {
-    public function __construct() {}
+    public function __construct()
+    {
+    }
 
     public function getSpecifications(): array
     {


### PR DESCRIPTION
| :ticket: Issue | [IBX-9121](https://issues.ibexa.co/browse/IBX-9121) |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Adds support for `IsUserEnabled` criterion in solr engine.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
https://doc.ibexa.co/en/latest/search/criteria_reference/isuserenabled_criterion/
Remove limitation about availability in solr engine.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
