### PR TITLE
Add possibility to perform a search on all translations ignoring current language settings setup in the platform

### DIFF
--- a/src/lib/CoreFilter/NativeCoreFilter.php
+++ b/src/lib/CoreFilter/NativeCoreFilter.php
@@ -24,6 +24,7 @@ use Ibexa\Solr\Gateway\EndpointResolver;
  * - prioritized languages fallback
  * - always available language fallback
  * - main language search
+ * - optionally ignore language filter, search in all translations
  */
 class NativeCoreFilter extends CoreFilter
 {
@@ -104,14 +105,20 @@ class NativeCoreFilter extends CoreFilter
         $excludeTranslationsFromAlwaysAvailable =
             $languageSettings['excludeTranslationsFromAlwaysAvailable'] ?? true;
 
+        $excludeCoreCriterion =
+            $languageSettings['excludeCoreCriterion'] ?? false;
+
         $criteria = [
             new CustomField(self::FIELD_DOCUMENT_TYPE, Operator::EQ, $documentTypeIdentifier),
-            $this->getCoreCriterion(
+        ];
+
+        if (!$excludeCoreCriterion) {
+            $criteria[] = $this->getCoreCriterion(
                 $languages,
                 $useAlwaysAvailable,
                 $excludeTranslationsFromAlwaysAvailable
-            ),
-        ];
+            );
+        }
 
         if ($query->filter !== null) {
             $criteria[] = $query->filter;


### PR DESCRIPTION
Include new flag in languageSettings to completely ignore language filter and search in all translations.

| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
