### PR TITLE
IBX-9727: Added missing type hints

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -127,12 +127,6 @@ parameters:
 			path: src/lib/CoreFilter.php
 
 		-
-			message: '#^Method Ibexa\\Solr\\CoreFilter\\NativeCoreFilter\:\:apply\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/CoreFilter/NativeCoreFilter.php
-
-		-
 			message: '#^Method Ibexa\\Solr\\CoreFilter\\NativeCoreFilter\:\:apply\(\) has parameter \$languageSettings with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -175,12 +169,6 @@ parameters:
 			path: src/lib/FieldMapper/BoostFactorProvider.php
 
 		-
-			message: '#^Method Ibexa\\Solr\\FieldMapper\\ContentFieldMapper\\Aggregate\:\:addMapper\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/FieldMapper/ContentFieldMapper/Aggregate.php
-
-		-
 			message: '#^Method Ibexa\\Solr\\FieldMapper\\ContentFieldMapper\\BlockDocumentsBaseContentFields\:\:getAncestorLocationsContentIds\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -217,12 +205,6 @@ parameters:
 			path: src/lib/FieldMapper/ContentFieldMapper/ContentDocumentLocationFields.php
 
 		-
-			message: '#^Method Ibexa\\Solr\\FieldMapper\\ContentTranslationFieldMapper\\Aggregate\:\:addMapper\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/FieldMapper/ContentTranslationFieldMapper/Aggregate.php
-
-		-
 			message: '#^Property Ibexa\\Contracts\\Core\\Search\\FieldType\:\:\$boost \(int\) does not accept float\.$#'
 			identifier: assign.propertyType
 			count: 1
@@ -251,12 +233,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/FieldMapper/IndexingDepthProvider.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\FieldMapper\\LocationFieldMapper\\Aggregate\:\:addMapper\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/FieldMapper/LocationFieldMapper/Aggregate.php
 
 		-
 			message: '#^Method Ibexa\\Solr\\FieldMapper\\LocationFieldMapper\\LocationDocumentBaseFields\:\:getAncestors\(\) return type has no value type specified in iterable type array\.$#'
@@ -391,22 +367,10 @@ parameters:
 			path: src/lib/Gateway/DistributionStrategy/StandaloneDistributionStrategy.php
 
 		-
-			message: '#^Method Ibexa\\Solr\\Gateway\\EndpointRegistry\:\:registerEndpoint\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Gateway/EndpointRegistry.php
-
-		-
 			message: '#^Method Ibexa\\Solr\\Gateway\\EndpointResolver\:\:getSearchTargets\(\) has parameter \$languageSettings with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Gateway/EndpointResolver.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\Gateway\\EndpointResolver\\NativeEndpointResolver\:\:getEntryEndpoint\(\) should return Ibexa\\Solr\\Gateway\\Endpoint but returns string\.$#'
-			identifier: return.type
-			count: 1
-			path: src/lib/Gateway/EndpointResolver/NativeEndpointResolver.php
 
 		-
 			message: '#^Method Ibexa\\Solr\\Gateway\\EndpointResolver\\NativeEndpointResolver\:\:getSearchTargets\(\) has parameter \$languageSettings with no value type specified in iterable type array\.$#'
@@ -415,16 +379,10 @@ parameters:
 			path: src/lib/Gateway/EndpointResolver/NativeEndpointResolver.php
 
 		-
-			message: '#^Method Ibexa\\Solr\\Gateway\\HttpClient\\Stream\:\:getResponseMessage\(\) has parameter \$method with no type specified\.$#'
-			identifier: missingType.parameter
+			message: '#^Return type \(string\) of method Ibexa\\Solr\\Gateway\\EndpointResolver\\NativeEndpointResolver\:\:getEntryEndpoint\(\) should be compatible with return type \(Ibexa\\Solr\\Gateway\\Endpoint\) of method Ibexa\\Solr\\Gateway\\EndpointResolver\:\:getEntryEndpoint\(\)$#'
+			identifier: method.childReturnType
 			count: 1
-			path: src/lib/Gateway/HttpClient/Stream.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\Gateway\\HttpClient\\Stream\:\:getResponseMessage\(\) has parameter \$path with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/lib/Gateway/HttpClient/Stream.php
+			path: src/lib/Gateway/EndpointResolver/NativeEndpointResolver.php
 
 		-
 			message: '#^Method Ibexa\\Solr\\Gateway\\Message\:\:__construct\(\) has parameter \$headers with no value type specified in iterable type array\.$#'
@@ -441,18 +399,6 @@ parameters:
 		-
 			message: '#^Default value of the parameter \#2 \$languageSettings \(array\{\}\) of method Ibexa\\Solr\\Gateway\\Native\:\:findContent\(\) is incompatible with type array\{languages\: array\<string\>\}\.$#'
 			identifier: parameter.defaultValue
-			count: 1
-			path: src/lib/Gateway/Native.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\Gateway\\Native\:\:commit\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Gateway/Native.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\Gateway\\Native\:\:deleteByQuery\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/lib/Gateway/Native.php
 
@@ -494,18 +440,6 @@ parameters:
 
 		-
 			message: '#^Method Ibexa\\Solr\\Gateway\\Native\:\:purgeEndpoint\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Gateway/Native.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\Gateway\\Native\:\:purgeEndpoint\(\) has parameter \$endpoint with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/lib/Gateway/Native.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\Gateway\\Native\:\:purgeIndex\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/lib/Gateway/Native.php
@@ -559,24 +493,6 @@ parameters:
 			path: src/lib/Handler.php
 
 		-
-			message: '#^Method Ibexa\\Solr\\Handler\:\:bulkIndexContent\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Handler.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\Handler\:\:bulkIndexDocuments\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Handler.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\Handler\:\:commit\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Handler.php
-
-		-
 			message: '#^Method Ibexa\\Solr\\Handler\:\:deleteAllItemsWithoutAdditionalLocation\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -589,38 +505,8 @@ parameters:
 			path: src/lib/Handler.php
 
 		-
-			message: '#^Method Ibexa\\Solr\\Handler\:\:deleteContent\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Handler.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\Handler\:\:deleteLocation\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Handler.php
-
-		-
 			message: '#^Method Ibexa\\Solr\\Handler\:\:generateDocument\(\) should return Ibexa\\Contracts\\Core\\Search\\Document but returns array\<Ibexa\\Contracts\\Core\\Search\\Document\>\.$#'
 			identifier: return.type
-			count: 1
-			path: src/lib/Handler.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\Handler\:\:indexContent\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Handler.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\Handler\:\:indexLocation\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Handler.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\Handler\:\:purgeIndex\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/lib/Handler.php
 
@@ -653,18 +539,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/lib/Handler.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\Indexer\:\:purge\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Indexer.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\Indexer\:\:updateSearchIndex\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Indexer.php
 
 		-
 			message: '#^Method Ibexa\\Solr\\Query\\Common\\AggregationVisitor\\AbstractRangeAggregationVisitor\:\:formatRangeValue\(\) has parameter \$value with no type specified\.$#'
@@ -715,12 +589,6 @@ parameters:
 			path: src/lib/Query/Common/AggregationVisitor/SubtreeTermAggregationVisitor.php
 
 		-
-			message: '#^Method Ibexa\\Solr\\Query\\Common\\CriterionVisitor\\Aggregate\:\:addVisitor\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Query/Common/CriterionVisitor/Aggregate.php
-
-		-
 			message: '#^Parameter \#2 \$array of function array_map expects array, array\<bool\|float\|int\|string\>\|bool\|float\|int\|string given\.$#'
 			identifier: argument.type
 			count: 1
@@ -737,12 +605,6 @@ parameters:
 			identifier: foreach.nonIterable
 			count: 1
 			path: src/lib/Query/Common/CriterionVisitor/ContentTypeIdentifierIn.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\Query\\Common\\CriterionVisitor\\CustomField\\CustomFieldIn\:\:isRegExp\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Query/Common/CriterionVisitor/CustomField/CustomFieldIn.php
 
 		-
 			message: '#^Method Ibexa\\Solr\\Query\\Common\\CriterionVisitor\\CustomField\\CustomFieldIn\:\:isRegExp\(\) has parameter \$preparedValue with no type specified\.$#'
@@ -793,12 +655,6 @@ parameters:
 			path: src/lib/Query/Common/CriterionVisitor/LogicalAnd.php
 
 		-
-			message: '#^Method Ibexa\\Solr\\Query\\Common\\CriterionVisitor\\LogicalAnd\:\:visit\(\) should return string but returns false\.$#'
-			identifier: return.type
-			count: 1
-			path: src/lib/Query/Common/CriterionVisitor/LogicalAnd.php
-
-		-
 			message: '#^Cannot call method visit\(\) on Ibexa\\Contracts\\Solr\\Query\\CriterionVisitor\|null\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -807,12 +663,6 @@ parameters:
 		-
 			message: '#^Cannot call method visit\(\) on Ibexa\\Contracts\\Solr\\Query\\CriterionVisitor\|null\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: src/lib/Query/Common/CriterionVisitor/LogicalOr.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\Query\\Common\\CriterionVisitor\\LogicalOr\:\:visit\(\) should return string but returns false\.$#'
-			identifier: return.type
 			count: 1
 			path: src/lib/Query/Common/CriterionVisitor/LogicalOr.php
 
@@ -907,12 +757,6 @@ parameters:
 			path: src/lib/Query/Common/QueryConverter/NativeQueryConverter.php
 
 		-
-			message: '#^Method Ibexa\\Solr\\Query\\Common\\QueryConverter\\NativeQueryConverter\:\:convert\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/lib/Query/Common/QueryConverter/NativeQueryConverter.php
-
-		-
 			message: '#^Method Ibexa\\Solr\\Query\\Common\\QueryTranslator\\Generator\\WordVisitor\:\:escapeWord\(\) should return string but returns string\|null\.$#'
 			identifier: return.type
 			count: 1
@@ -921,12 +765,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\Contracts\\Solr\\Query\\SortClauseVisitor\:\:visit\(\) invoked with 2 parameters, 1 required\.$#'
 			identifier: arguments.count
-			count: 1
-			path: src/lib/Query/Common/SortClauseVisitor/Aggregate.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\Query\\Common\\SortClauseVisitor\\Aggregate\:\:addVisitor\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/lib/Query/Common/SortClauseVisitor/Aggregate.php
 
@@ -971,12 +809,6 @@ parameters:
 			identifier: foreach.nonIterable
 			count: 1
 			path: src/lib/Query/Content/CriterionVisitor/Ancestor.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\Query\\Content\\CriterionVisitor\\FullText\:\:getQueryFields\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Query/Content/CriterionVisitor/FullText.php
 
 		-
 			message: '#^Method Ibexa\\Solr\\Query\\Content\\CriterionVisitor\\FullText\:\:getSearchFields\(\) return type has no value type specified in iterable type array\.$#'
@@ -1153,12 +985,6 @@ parameters:
 			path: src/lib/ResultExtractor/AggregationResultExtractor/DispatcherAggregationResultExtractor.php
 
 		-
-			message: '#^Property Ibexa\\Solr\\ResultExtractor\\AggregationResultExtractor\\DispatcherAggregationResultExtractor\:\:\$extractors \(array\<Ibexa\\Contracts\\Solr\\ResultExtractor\\AggregationResultExtractor\>\) does not accept iterable\<Ibexa\\Contracts\\Solr\\ResultExtractor\\AggregationResultExtractor\>\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/lib/ResultExtractor/AggregationResultExtractor/DispatcherAggregationResultExtractor.php
-
-		-
 			message: '#^Method Ibexa\\Solr\\ResultExtractor\\AggregationResultExtractor\\NestedAggregationResultExtractor\:\:canVisit\(\) has parameter \$languageFilter with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -1171,22 +997,10 @@ parameters:
 			path: src/lib/ResultExtractor/AggregationResultExtractor/NestedAggregationResultExtractor.php
 
 		-
-			message: '#^Method Ibexa\\Solr\\ResultExtractor\\AggregationResultExtractor\\RangeAggregationKeyMapper\\DateTimeRangeAggregationKeyMapper\:\:map\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/DateTimeRangeAggregationKeyMapper.php
-
-		-
 			message: '#^Method Ibexa\\Solr\\ResultExtractor\\AggregationResultExtractor\\RangeAggregationKeyMapper\\DateTimeRangeAggregationKeyMapper\:\:map\(\) has parameter \$languageFilter with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/DateTimeRangeAggregationKeyMapper.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\ResultExtractor\\AggregationResultExtractor\\RangeAggregationKeyMapper\\FloatRangeAggregationKeyMapper\:\:map\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/FloatRangeAggregationKeyMapper.php
 
 		-
 			message: '#^Method Ibexa\\Solr\\ResultExtractor\\AggregationResultExtractor\\RangeAggregationKeyMapper\\FloatRangeAggregationKeyMapper\:\:map\(\) has parameter \$languageFilter with no value type specified in iterable type array\.$#'
@@ -1195,22 +1009,10 @@ parameters:
 			path: src/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/FloatRangeAggregationKeyMapper.php
 
 		-
-			message: '#^Method Ibexa\\Solr\\ResultExtractor\\AggregationResultExtractor\\RangeAggregationKeyMapper\\IntRangeAggregationKeyMapper\:\:map\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/IntRangeAggregationKeyMapper.php
-
-		-
 			message: '#^Method Ibexa\\Solr\\ResultExtractor\\AggregationResultExtractor\\RangeAggregationKeyMapper\\IntRangeAggregationKeyMapper\:\:map\(\) has parameter \$languageFilter with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/IntRangeAggregationKeyMapper.php
-
-		-
-			message: '#^Method Ibexa\\Solr\\ResultExtractor\\AggregationResultExtractor\\RangeAggregationKeyMapper\\NullRangeAggregationKeyMapper\:\:map\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/NullRangeAggregationKeyMapper.php
 
 		-
 			message: '#^Method Ibexa\\Solr\\ResultExtractor\\AggregationResultExtractor\\RangeAggregationKeyMapper\\NullRangeAggregationKeyMapper\:\:map\(\) has parameter \$languageFilter with no value type specified in iterable type array\.$#'
@@ -1483,36 +1285,6 @@ parameters:
 			path: src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationResultExtractor.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Solr\\DependencyInjection\\IbexaSolrExtensionExtensionTest\:\:dataProvideForTestBoostFactorMap\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Solr\\DependencyInjection\\IbexaSolrExtensionExtensionTest\:\:dataProviderForTestConnection\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Solr\\DependencyInjection\\IbexaSolrExtensionExtensionTest\:\:dataProviderForTestEndpoint\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Solr\\DependencyInjection\\IbexaSolrExtensionExtensionTest\:\:getMinimalConfiguration\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Solr\\DependencyInjection\\IbexaSolrExtensionExtensionTest\:\:testBoostFactorMap\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Bundle\\Solr\\DependencyInjection\\IbexaSolrExtensionExtensionTest\:\:testBoostFactorMap\(\) has parameter \$configuration with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -1525,62 +1297,8 @@ parameters:
 			path: tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Solr\\DependencyInjection\\IbexaSolrExtensionExtensionTest\:\:testConnection\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Solr\\DependencyInjection\\IbexaSolrExtensionExtensionTest\:\:testConnectionEndpointDefaults\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Solr\\DependencyInjection\\IbexaSolrExtensionExtensionTest\:\:testConnectionEndpointUniqueDefaults\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Bundle\\Solr\\DependencyInjection\\IbexaSolrExtensionExtensionTest\:\:testConnectionLoad\(\) has parameter \$configurationValues with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Solr\\DependencyInjection\\IbexaSolrExtensionExtensionTest\:\:testConnectionMappingDefaults\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Solr\\DependencyInjection\\IbexaSolrExtensionExtensionTest\:\:testEmpty\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Solr\\DependencyInjection\\IbexaSolrExtensionExtensionTest\:\:testEndpoint\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Solr\\DependencyInjection\\IbexaSolrExtensionExtensionTest\:\:testEndpoint\(\) has parameter \$endpointValues with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Solr\\DependencyInjection\\IbexaSolrExtensionExtensionTest\:\:testEndpoint\(\) has parameter \$expectedArgument with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Solr\\DependencyInjection\\IbexaSolrExtensionExtensionTest\:\:testEndpointCoreRequired\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
 
@@ -1603,18 +1321,6 @@ parameters:
 			path: tests/bundle/Gateway/UpdateSerializer/JsonUpdateSerializerTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Container\\Compiler\\AggregateCriterionVisitorPassTest\:\:testAddVisitor\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Container/Compiler/AggregateCriterionVisitorPassTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Container\\Compiler\\AggregateSortClauseVisitorPassTest\:\:testAddVisitor\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Container/Compiler/AggregateSortClauseVisitorPassTest.php
-
-		-
 			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Ibexa\\\\Solr\\\\CoreFilter'' and Ibexa\\Solr\\CoreFilter will always evaluate to true\.$#'
 			identifier: staticMethod.alreadyNarrowedType
 			count: 1
@@ -1633,20 +1339,8 @@ parameters:
 			path: tests/lib/Gateway/UpdateSerializerFactoryTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\FieldMapper\\BoostFactorProviderTest\:\:getContentTypeStub\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Solr\\Search\\FieldMapper\\BoostFactorProviderTest\:\:getContentTypeStub\(\) has parameter \$identifier with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\FieldMapper\\BoostFactorProviderTest\:\:getFieldBoostProvider\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
 
@@ -1657,32 +1351,8 @@ parameters:
 			path: tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\FieldMapper\\BoostFactorProviderTest\:\:getFieldDefinitionStub\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Solr\\Search\\FieldMapper\\BoostFactorProviderTest\:\:getFieldDefinitionStub\(\) has parameter \$identifier with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\FieldMapper\\BoostFactorProviderTest\:\:providerForTestGetContentFieldBoostFactor\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\FieldMapper\\BoostFactorProviderTest\:\:providerForTestGetContentMetaFieldBoostFactor\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\FieldMapper\\BoostFactorProviderTest\:\:testGetContentFieldBoostFactor\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
 
@@ -1693,40 +1363,10 @@ parameters:
 			path: tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\FieldMapper\\BoostFactorProviderTest\:\:testGetContentMetaFieldBoostFactor\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Solr\\Search\\FieldMapper\\BoostFactorProviderTest\:\:testGetContentMetaFieldBoostFactor\(\) has parameter \$map with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\FieldMapper\\IndexingDepthProviderTest\:\:getContentTypeStub\(\) has parameter \$identifier with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/Search/FieldMapper/IndexingDepthProviderTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\FieldMapper\\IndexingDepthProviderTest\:\:testGetMaxDepth\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/FieldMapper/IndexingDepthProviderTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\FieldMapper\\IndexingDepthProviderTest\:\:testGetMaxDepthForContentType\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/FieldMapper/IndexingDepthProviderTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\FieldMapper\\IndexingDepthProviderTest\:\:testGetMaxDepthForContentTypeReturnsDefaultValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/FieldMapper/IndexingDepthProviderTest.php
 
 		-
 			message: '#^Parameter \#1 \$endpointRegistry of class Ibexa\\Solr\\Gateway\\DistributionStrategy\\StandaloneDistributionStrategy constructor expects Ibexa\\Solr\\Gateway\\EndpointRegistry, PHPUnit\\Framework\\MockObject\\MockObject given\.$#'
@@ -1741,8 +1381,8 @@ parameters:
 			path: tests/lib/Search/Gateway/DistributionStrategy/StandaloneDistributionStrategyTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointResolver\\NativeEndpointResolverTest\:\:getEndpointResolver\(\) has no return type specified\.$#'
-			identifier: missingType.return
+			message: '#^Instanceof between Ibexa\\Solr\\Gateway\\EndpointResolver\\NativeEndpointResolver and Ibexa\\Solr\\Gateway\\SingleEndpointResolver will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
 			count: 1
 			path: tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
 
@@ -1771,80 +1411,8 @@ parameters:
 			path: tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointResolver\\NativeEndpointResolverTest\:\:getIndexingTargetThrowsRuntimeException\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointResolver\\NativeEndpointResolverTest\:\:providerForTestGetEndpoints\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointResolver\\NativeEndpointResolverTest\:\:providerForTestGetSearchTargets\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointResolver\\NativeEndpointResolverTest\:\:providerForTestGetSearchTargetsThrowsRuntimeException\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointResolver\\NativeEndpointResolverTest\:\:testGetEndpoints\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointResolver\\NativeEndpointResolverTest\:\:testGetEndpointsThrowsRuntimeException\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointResolver\\NativeEndpointResolverTest\:\:testGetEntryEndpoint\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointResolver\\NativeEndpointResolverTest\:\:testGetEntryEndpointThrowsRuntimeException\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointResolver\\NativeEndpointResolverTest\:\:testGetIndexingTarget\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointResolver\\NativeEndpointResolverTest\:\:testGetIndexingTargetReturnsDefaultEndpoint\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointResolver\\NativeEndpointResolverTest\:\:testGetMainLanguagesEndpoint\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointResolver\\NativeEndpointResolverTest\:\:testGetMainLanguagesEndpointReturnsNull\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointResolver\\NativeEndpointResolverTest\:\:testGetSearchTargets\(\) has no return type specified\.$#'
-			identifier: missingType.return
+			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointResolver\\NativeEndpointResolverTest\:\:providerForTestGetSearchTargets\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
 
@@ -1855,128 +1423,14 @@ parameters:
 			path: tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointResolver\\NativeEndpointResolverTest\:\:testGetSearchTargetsThrowsRuntimeException\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointResolver\\NativeEndpointResolverTest\:\:testGetSearchTargetsThrowsRuntimeException\(\) has parameter \$languageSettings with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointTest\:\:testEndpointDsnParsingOverridesAllIfSet\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Gateway/EndpointTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointTest\:\:testEndpointDsnParsingWithAll\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Gateway/EndpointTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointTest\:\:testEndpointDsnParsingWithFragment\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Gateway/EndpointTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointTest\:\:testEndpointDsnParsingWithQuery\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Gateway/EndpointTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Gateway\\EndpointTest\:\:testEndpointDsnParsingWithoutUser\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Gateway/EndpointTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Query\\Content\\CriterionVisitor\\FullTextTest\:\:getFullTextCriterionVisitor\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Query/Content/CriterionVisitor/FullTextTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Query\\Content\\CriterionVisitor\\FullTextTest\:\:getFullTextCriterionVisitor\(\) has parameter \$fieldTypes with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/Search/Query/Content/CriterionVisitor/FullTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Query\\Content\\CriterionVisitor\\FullTextTest\:\:testVisitBoost\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Query/Content/CriterionVisitor/FullTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Query\\Content\\CriterionVisitor\\FullTextTest\:\:testVisitBoostMultipleWords\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Query/Content/CriterionVisitor/FullTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Query\\Content\\CriterionVisitor\\FullTextTest\:\:testVisitBoostUnknownField\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Query/Content/CriterionVisitor/FullTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Query\\Content\\CriterionVisitor\\FullTextTest\:\:testVisitBoostUnknownFieldMultipleWords\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Query/Content/CriterionVisitor/FullTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Query\\Content\\CriterionVisitor\\FullTextTest\:\:testVisitErrorCorrection\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Query/Content/CriterionVisitor/FullTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Query\\Content\\CriterionVisitor\\FullTextTest\:\:testVisitFuzzy\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Query/Content/CriterionVisitor/FullTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Query\\Content\\CriterionVisitor\\FullTextTest\:\:testVisitFuzzyBoost\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Query/Content/CriterionVisitor/FullTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Query\\Content\\CriterionVisitor\\FullTextTest\:\:testVisitFuzzyBoostMultipleWords\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Query/Content/CriterionVisitor/FullTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Query\\Content\\CriterionVisitor\\FullTextTest\:\:testVisitFuzzyMultipleWords\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Query/Content/CriterionVisitor/FullTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Query\\Content\\CriterionVisitor\\FullTextTest\:\:testVisitSimple\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Query/Content/CriterionVisitor/FullTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Query\\Content\\CriterionVisitor\\FullTextTest\:\:testVisitSimpleMultipleWords\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Search/Query/Content/CriterionVisitor/FullTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\Query\\Content\\CriterionVisitor\\FullTextTest\:\:testVisitWithRelated\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: tests/lib/Search/Query/Content/CriterionVisitor/FullTextTest.php
 
@@ -2149,12 +1603,6 @@ parameters:
 			path: tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeGroupAggregationKeyMapperTest.php
 
 		-
-			message: '#^Parameter \#1 \$contentTypeService of class Ibexa\\Solr\\ResultExtractor\\AggregationResultExtractor\\TermAggregationKeyMapper\\ContentTypeGroupAggregationKeyMapper constructor expects Ibexa\\Contracts\\Core\\Repository\\ContentTypeService, PHPUnit\\Framework\\MockObject\\MockObject given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeGroupAggregationKeyMapperTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Solr\\Search\\ResultExtractor\\AggregationResultExtractor\\TermAggregationKeyMapper\\CountryAggregationKeyMapperTest\:\:dataProviderForTestMap\(\) return type has no value type specified in iterable type iterable\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -2193,18 +1641,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\Tests\\Solr\\Search\\ResultExtractor\\AggregationResultExtractor\\TermAggregationKeyMapper\\LanguageAggregationKeyMapperTest\:\:configureLanguageServiceMock\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LanguageAggregationKeyMapperTest.php
-
-		-
-			message: '#^Parameter \#1 \$aggregation of method Ibexa\\Solr\\ResultExtractor\\AggregationResultExtractor\\TermAggregationKeyMapper\\CountryAggregationKeyMapper\:\:map\(\) expects Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Query\\Aggregation\\Field\\CountryTermAggregation, Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Query\\Aggregation&PHPUnit\\Framework\\MockObject\\MockObject given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LanguageAggregationKeyMapperTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\Solr\\Search\\ResultExtractor\\AggregationResultExtractor\\TermAggregationKeyMapper\\LanguageAggregationKeyMapperTest\:\:\$mapper \(Ibexa\\Solr\\ResultExtractor\\AggregationResultExtractor\\TermAggregationKeyMapper\\CountryAggregationKeyMapper\) does not accept Ibexa\\Solr\\ResultExtractor\\AggregationResultExtractor\\TermAggregationKeyMapper\\LanguageAggregationKeyMapper\.$#'
-			identifier: assign.propertyType
 			count: 1
 			path: tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LanguageAggregationKeyMapperTest.php
 

--- a/src/bundle/ApiLoader/IndexingDepthProviderFactory.php
+++ b/src/bundle/ApiLoader/IndexingDepthProviderFactory.php
@@ -20,15 +20,9 @@ class IndexingDepthProviderFactory implements ContainerAwareInterface
 
     private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
-    /**
-     * @var string
-     */
-    private $defaultConnection;
+    private string $defaultConnection;
 
-    /**
-     * @var string
-     */
-    private $indexingDepthProviderClass;
+    private string $indexingDepthProviderClass;
 
     public function __construct(
         RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,

--- a/src/bundle/ApiLoader/SolrEngineFactory.php
+++ b/src/bundle/ApiLoader/SolrEngineFactory.php
@@ -24,23 +24,17 @@ class SolrEngineFactory
     /** @var string */
     private $searchEngineClass;
 
-    /** @var \Ibexa\Solr\Gateway\GatewayRegistry */
-    private $gatewayRegistry;
+    private GatewayRegistry $gatewayRegistry;
 
-    /** @var \Ibexa\Solr\CoreFilter\CoreFilterRegistry */
-    private $coreFilterRegistry;
+    private CoreFilterRegistry $coreFilterRegistry;
 
-    /** @var \Ibexa\Contracts\Core\Persistence\Content\Handler */
-    private $contentHandler;
+    private Handler $contentHandler;
 
-    /** @var \Ibexa\Contracts\Solr\DocumentMapper */
-    private $documentMapper;
+    private DocumentMapper $documentMapper;
 
-    /** @var \Ibexa\Solr\ResultExtractor */
-    private $contentResultExtractor;
+    private ResultExtractor $contentResultExtractor;
 
-    /** @var \Ibexa\Solr\ResultExtractor */
-    private $locationResultExtractor;
+    private ResultExtractor $locationResultExtractor;
 
     public function __construct(
         RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -116,14 +116,14 @@ class Configuration implements ConfigurationInterface
             ->prototype('array')
                 ->beforeNormalization()
                     ->ifTrue(
-                        static function ($v) {
+                        static function ($v): bool {
                             return
                                 !empty($v['mapping']) && !\is_array($v['mapping'])
                             ;
                         }
                     )
                     ->then(
-                        static function ($v) {
+                        static function (array $v) {
                             // If single endpoint is set for Content mapping, use it as default
                             // mapping for Content index
                             $v['mapping'] = [
@@ -136,7 +136,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->beforeNormalization()
                     ->ifTrue(
-                        static function ($v) {
+                        static function ($v): bool {
                             return
                                 empty($v['entry_endpoints']) &&
                                 (
@@ -149,7 +149,7 @@ class Configuration implements ConfigurationInterface
                     )
                     ->then(
                         // If entry endpoints are not provided use mapping endpoints
-                        static function ($v) {
+                        static function (array $v) {
                             $endpointSet = [];
 
                             if (!empty($v['mapping']['translations'])) {
@@ -318,7 +318,7 @@ class Configuration implements ConfigurationInterface
                                 ->useAttributeAsKey('content_type_identifier')
                                 ->beforeNormalization()
                                     ->always(
-                                        static function (array $v) {
+                                        static function (array $v): array {
                                             $valuesMapped = [];
                                             foreach ($v as $key => $value) {
                                                 if (\is_array($value)) {
@@ -354,7 +354,7 @@ class Configuration implements ConfigurationInterface
                                 ->useAttributeAsKey('content_type_identifier')
                                 ->beforeNormalization()
                                     ->always(
-                                        static function (array $v) {
+                                        static function (array $v): array {
                                             $valuesMapped = [];
                                             foreach ($v as $key => $value) {
                                                 if (\is_array($value)) {
@@ -373,7 +373,7 @@ class Configuration implements ConfigurationInterface
                                     ->useAttributeAsKey('meta_field_name')
                                     ->validate()
                                         ->ifTrue(
-                                            function (array $v) {
+                                            function (array $v): bool {
                                                 foreach (array_keys($v) as $key) {
                                                     if (!\in_array($key, $this->metaFieldNames, true)) {
                                                         return true;

--- a/src/contracts/Query/CriterionVisitor.php
+++ b/src/contracts/Query/CriterionVisitor.php
@@ -144,7 +144,7 @@ abstract class CriterionVisitor
 
         return preg_replace_callback(
             '/([' . $reservedCharacters . '])/',
-            static function ($matches) {
+            static function ($matches): string {
                 return '\\' . $matches[0];
             },
             $string

--- a/src/lib/CoreFilter/CoreFilterRegistry.php
+++ b/src/lib/CoreFilter/CoreFilterRegistry.php
@@ -13,7 +13,7 @@ use OutOfBoundsException;
 final class CoreFilterRegistry
 {
     /** @var \Ibexa\Solr\CoreFilter[] */
-    private $coreFilters;
+    private array $coreFilters;
 
     /**
      * @param \Ibexa\Solr\CoreFilter[] $coreFilters

--- a/src/lib/CoreFilter/NativeCoreFilter.php
+++ b/src/lib/CoreFilter/NativeCoreFilter.php
@@ -77,10 +77,8 @@ class NativeCoreFilter extends CoreFilter
 
     /**
      * Indicates presence of main languages index.
-     *
-     * @var bool
      */
-    private $hasMainLanguagesEndpoint;
+    private bool $hasMainLanguagesEndpoint;
 
     public function __construct(EndpointResolver $endpointResolver)
     {
@@ -89,7 +87,7 @@ class NativeCoreFilter extends CoreFilter
         );
     }
 
-    public function apply(Query $query, array $languageSettings, $documentTypeIdentifier)
+    public function apply(Query $query, array $languageSettings, $documentTypeIdentifier): void
     {
         $languages = (
             empty($languageSettings['languages']) ?
@@ -267,7 +265,7 @@ class NativeCoreFilter extends CoreFilter
      *
      * @return string[]
      */
-    private function getExcludedLanguageCodes(array $languageCodes, $selectedLanguageCode = null)
+    private function getExcludedLanguageCodes(array $languageCodes, $selectedLanguageCode = null): array
     {
         $excludedLanguageCodes = [];
 

--- a/src/lib/DocumentMapper/NativeDocumentMapper.php
+++ b/src/lib/DocumentMapper/NativeDocumentMapper.php
@@ -9,6 +9,7 @@ namespace Ibexa\Solr\DocumentMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content;
 use Ibexa\Contracts\Core\Persistence\Content\Location;
+use Ibexa\Contracts\Core\Persistence\Content\Location\Handler;
 use Ibexa\Contracts\Core\Persistence\Content\Location\Handler as LocationHandler;
 use Ibexa\Contracts\Core\Search\Document;
 use Ibexa\Contracts\Solr\DocumentMapper;
@@ -21,37 +22,20 @@ use Ibexa\Contracts\Solr\FieldMapper\LocationFieldMapper;
  */
 class NativeDocumentMapper implements DocumentMapper
 {
-    /**
-     * @var \Ibexa\Contracts\Solr\FieldMapper\ContentFieldMapper
-     */
-    private $blockFieldMapper;
+    private ContentFieldMapper $blockFieldMapper;
 
-    /**
-     * @var \Ibexa\Contracts\Solr\FieldMapper\ContentTranslationFieldMapper
-     */
-    private $blockTranslationFieldMapper;
+    private ContentTranslationFieldMapper $blockTranslationFieldMapper;
 
-    /**
-     * @var \Ibexa\Contracts\Solr\FieldMapper\ContentFieldMapper
-     */
-    private $contentFieldMapper;
+    private ContentFieldMapper $contentFieldMapper;
 
-    /**
-     * @var \Ibexa\Contracts\Solr\FieldMapper\ContentTranslationFieldMapper
-     */
-    private $contentTranslationFieldMapper;
+    private ContentTranslationFieldMapper $contentTranslationFieldMapper;
 
-    /**
-     * @var \Ibexa\Contracts\Solr\FieldMapper\LocationFieldMapper
-     */
-    private $locationFieldMapper;
+    private LocationFieldMapper $locationFieldMapper;
 
     /**
      * Location handler.
-     *
-     * @var \Ibexa\Contracts\Core\Persistence\Content\Location\Handler
      */
-    protected $locationHandler;
+    protected Handler $locationHandler;
 
     /**
      * Creates a new document mapper.
@@ -77,7 +61,7 @@ class NativeDocumentMapper implements DocumentMapper
      *
      * @return \Ibexa\Contracts\Core\Search\Document[]
      */
-    public function mapContentBlock(Content $content)
+    public function mapContentBlock(Content $content): array
     {
         $contentInfo = $content->versionInfo->contentInfo;
         $locations = $this->locationHandler->loadLocationsByContent($contentInfo->id);
@@ -155,7 +139,7 @@ class NativeDocumentMapper implements DocumentMapper
      *
      * @return string
      */
-    public function generateContentDocumentId($contentId, $languageCode = null)
+    public function generateContentDocumentId($contentId, $languageCode = null): string
     {
         return strtolower("content{$contentId}lang{$languageCode}");
     }
@@ -175,7 +159,7 @@ class NativeDocumentMapper implements DocumentMapper
      *
      * @return string
      */
-    public function generateLocationDocumentId($locationId, $languageCode = null)
+    public function generateLocationDocumentId($locationId, $languageCode = null): string
     {
         return strtolower("location{$locationId}lang{$languageCode}");
     }
@@ -205,7 +189,7 @@ class NativeDocumentMapper implements DocumentMapper
      *
      * @return \Ibexa\Contracts\Core\Search\Field[]
      */
-    private function getBlockTranslationFields(Content $content, $languageCode)
+    private function getBlockTranslationFields(Content $content, int|string $languageCode)
     {
         $fields = [];
 
@@ -241,7 +225,7 @@ class NativeDocumentMapper implements DocumentMapper
      *
      * @return \Ibexa\Contracts\Core\Search\Field[]
      */
-    private function getContentTranslationFields(Content $content, $languageCode)
+    private function getContentTranslationFields(Content $content, int|string $languageCode)
     {
         $fields = [];
 

--- a/src/lib/DocumentMapper/NativeDocumentMapper.php
+++ b/src/lib/DocumentMapper/NativeDocumentMapper.php
@@ -185,11 +185,9 @@ class NativeDocumentMapper implements DocumentMapper
      * Returns an array of fields for the given $content and $languageCode, to be added to the
      * corresponding block documents.
      *
-     * @param string $languageCode
-     *
      * @return \Ibexa\Contracts\Core\Search\Field[]
      */
-    private function getBlockTranslationFields(Content $content, int|string $languageCode)
+    private function getBlockTranslationFields(Content $content, string $languageCode)
     {
         $fields = [];
 
@@ -221,11 +219,9 @@ class NativeDocumentMapper implements DocumentMapper
      * Returns an array of fields for the given $content and $languageCode, to be added to the
      * corresponding Content document.
      *
-     * @param string $languageCode
-     *
      * @return \Ibexa\Contracts\Core\Search\Field[]
      */
-    private function getContentTranslationFields(Content $content, int|string $languageCode)
+    private function getContentTranslationFields(Content $content, string $languageCode)
     {
         $fields = [];
 

--- a/src/lib/FieldMapper/BoostFactorProvider.php
+++ b/src/lib/FieldMapper/BoostFactorProvider.php
@@ -17,24 +17,18 @@ class BoostFactorProvider
 {
     /**
      * Internal map key used to access Content field boost factors.
-     *
-     * @var string
      */
-    private static $keyContentFields = 'content-fields';
+    private static string $keyContentFields = 'content-fields';
 
     /**
      * Internal map key used to access meta field boost factors.
-     *
-     * @var string
      */
-    private static $keyMetaFields = 'meta-fields';
+    private static string $keyMetaFields = 'meta-fields';
 
     /**
      * Internal map wildcard type key.
-     *
-     * @var string
      */
-    private static $keyAny = '*';
+    private static string $keyAny = '*';
 
     /**
      * Internal map of field boost factors.
@@ -69,17 +63,13 @@ class BoostFactorProvider
      *     ],
      * ];
      * ```
-     *
-     * @var array
      */
-    private $map;
+    private array $map;
 
     /**
      * Boost factor to be used if no mapping is found.
-     *
-     * @var float
      */
-    private $defaultBoostFactor = 1.0;
+    private float $defaultBoostFactor = 1.0;
 
     public function __construct(array $map = [])
     {

--- a/src/lib/FieldMapper/ContentFieldMapper/Aggregate.php
+++ b/src/lib/FieldMapper/ContentFieldMapper/Aggregate.php
@@ -36,17 +36,20 @@ class Aggregate extends ContentFieldMapper
     /**
      * Adds given $mapper to the internal array as the next one in priority.
      */
-    public function addMapper(ContentFieldMapper $mapper)
+    public function addMapper(ContentFieldMapper $mapper): void
     {
         $this->mappers[] = $mapper;
     }
 
-    public function accept(Content $content)
+    public function accept(Content $content): bool
     {
         return true;
     }
 
-    public function mapFields(Content $content)
+    /**
+     * @return mixed[]
+     */
+    public function mapFields(Content $content): array
     {
         $fields = [];
 

--- a/src/lib/FieldMapper/ContentFieldMapper/BlockDocumentsBaseContentFields.php
+++ b/src/lib/FieldMapper/ContentFieldMapper/BlockDocumentsBaseContentFields.php
@@ -8,6 +8,7 @@
 namespace Ibexa\Solr\FieldMapper\ContentFieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content;
+use Ibexa\Contracts\Core\Persistence\Content\Location\Handler;
 use Ibexa\Contracts\Core\Persistence\Content\Location\Handler as LocationHandler;
 use Ibexa\Contracts\Core\Persistence\Content\ObjectState\Handler as ObjectStateHandler;
 use Ibexa\Contracts\Core\Persistence\Content\Section\Handler as SectionHandler;
@@ -22,25 +23,13 @@ use Ibexa\Contracts\Solr\FieldMapper\ContentFieldMapper;
  */
 class BlockDocumentsBaseContentFields extends ContentFieldMapper
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Persistence\Content\Location\Handler
-     */
-    protected $locationHandler;
+    protected Handler $locationHandler;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Persistence\Content\Type\Handler
-     */
-    protected $contentTypeHandler;
+    protected ContentTypeHandler $contentTypeHandler;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Persistence\Content\ObjectState\Handler
-     */
-    protected $objectStateHandler;
+    protected ObjectStateHandler $objectStateHandler;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Persistence\Content\Section\Handler
-     */
-    protected $sectionHandler;
+    protected SectionHandler $sectionHandler;
 
     public function __construct(
         LocationHandler $locationHandler,
@@ -54,12 +43,12 @@ class BlockDocumentsBaseContentFields extends ContentFieldMapper
         $this->sectionHandler = $sectionHandler;
     }
 
-    public function accept(Content $content)
+    public function accept(Content $content): bool
     {
         return true;
     }
 
-    public function mapFields(Content $content)
+    public function mapFields(Content $content): array
     {
         $versionInfo = $content->versionInfo;
         $contentInfo = $content->versionInfo->contentInfo;
@@ -203,7 +192,7 @@ class BlockDocumentsBaseContentFields extends ContentFieldMapper
      *
      * @return array
      */
-    protected function getObjectStateIds($contentId)
+    protected function getObjectStateIds($contentId): array
     {
         $objectStateIds = [];
 

--- a/src/lib/FieldMapper/ContentFieldMapper/ContentDocumentBaseFields.php
+++ b/src/lib/FieldMapper/ContentFieldMapper/ContentDocumentBaseFields.php
@@ -18,12 +18,12 @@ use Ibexa\Contracts\Solr\FieldMapper\ContentFieldMapper;
  */
 class ContentDocumentBaseFields extends ContentFieldMapper
 {
-    public function accept(Content $content)
+    public function accept(Content $content): bool
     {
         return true;
     }
 
-    public function mapFields(Content $content)
+    public function mapFields(Content $content): array
     {
         return [
             new Field(

--- a/src/lib/FieldMapper/ContentFieldMapper/ContentDocumentLocationFields.php
+++ b/src/lib/FieldMapper/ContentFieldMapper/ContentDocumentLocationFields.php
@@ -10,6 +10,7 @@ namespace Ibexa\Solr\FieldMapper\ContentFieldMapper;
 use Ibexa\Contracts\Core\Persistence\Bookmark\Handler as BookmarkHandler;
 use Ibexa\Contracts\Core\Persistence\Content;
 use Ibexa\Contracts\Core\Persistence\Content\Location;
+use Ibexa\Contracts\Core\Persistence\Content\Location\Handler;
 use Ibexa\Contracts\Core\Persistence\Content\Location\Handler as LocationHandler;
 use Ibexa\Contracts\Core\Search\Field;
 use Ibexa\Contracts\Core\Search\FieldType;
@@ -20,10 +21,7 @@ use Ibexa\Contracts\Solr\FieldMapper\ContentFieldMapper;
  */
 class ContentDocumentLocationFields extends ContentFieldMapper
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Persistence\Content\Location\Handler
-     */
-    protected $locationHandler;
+    protected Handler $locationHandler;
 
     private BookmarkHandler $bookmarkHandler;
 
@@ -35,12 +33,15 @@ class ContentDocumentLocationFields extends ContentFieldMapper
         $this->locationHandler = $locationHandler;
     }
 
-    public function accept(Content $content)
+    public function accept(Content $content): bool
     {
         return true;
     }
 
-    public function mapFields(Content $content)
+    /**
+     * @return \Ibexa\Contracts\Core\Search\Field[]
+     */
+    public function mapFields(Content $content): array
     {
         $locations = $this->locationHandler->loadLocationsByContent($content->versionInfo->contentInfo->id);
         $mainLocation = null;

--- a/src/lib/FieldMapper/ContentTranslationFieldMapper/Aggregate.php
+++ b/src/lib/FieldMapper/ContentTranslationFieldMapper/Aggregate.php
@@ -36,17 +36,20 @@ class Aggregate extends ContentTranslationFieldMapper
     /**
      * Adds given $mapper to the internal array as the next one in priority.
      */
-    public function addMapper(ContentTranslationFieldMapper $mapper)
+    public function addMapper(ContentTranslationFieldMapper $mapper): void
     {
         $this->mappers[] = $mapper;
     }
 
-    public function accept(Content $content, $languageCode)
+    public function accept(Content $content, $languageCode): bool
     {
         return true;
     }
 
-    public function mapFields(Content $content, $languageCode)
+    /**
+     * @return mixed[]
+     */
+    public function mapFields(Content $content, $languageCode): array
     {
         $fields = [];
 

--- a/src/lib/FieldMapper/ContentTranslationFieldMapper/BlockDocumentsContentFields.php
+++ b/src/lib/FieldMapper/ContentTranslationFieldMapper/BlockDocumentsContentFields.php
@@ -10,9 +10,11 @@ namespace Ibexa\Solr\FieldMapper\ContentTranslationFieldMapper;
 use Ibexa\Contracts\Core\Persistence\Content;
 use Ibexa\Contracts\Core\Persistence\Content\Type as ContentType;
 use Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition;
+use Ibexa\Contracts\Core\Persistence\Content\Type\Handler;
 use Ibexa\Contracts\Core\Persistence\Content\Type\Handler as ContentTypeHandler;
 use Ibexa\Contracts\Core\Search\Field;
 use Ibexa\Contracts\Core\Search\FieldType;
+use Ibexa\Contracts\Core\Search\FieldType\TextField;
 use Ibexa\Contracts\Solr\FieldMapper\ContentTranslationFieldMapper;
 use Ibexa\Core\Search\Common\FieldNameGenerator;
 use Ibexa\Core\Search\Common\FieldRegistry;
@@ -23,25 +25,13 @@ use Ibexa\Solr\FieldMapper\BoostFactorProvider;
  */
 class BlockDocumentsContentFields extends ContentTranslationFieldMapper
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Persistence\Content\Type\Handler
-     */
-    protected $contentTypeHandler;
+    protected Handler $contentTypeHandler;
 
-    /**
-     * @var \Ibexa\Core\Search\Common\FieldRegistry
-     */
-    protected $fieldRegistry;
+    protected FieldRegistry $fieldRegistry;
 
-    /**
-     * @var \Ibexa\Core\Search\Common\FieldNameGenerator
-     */
-    protected $fieldNameGenerator;
+    protected FieldNameGenerator $fieldNameGenerator;
 
-    /**
-     * @var \Ibexa\Solr\FieldMapper\BoostFactorProvider
-     */
-    protected $boostFactorProvider;
+    protected BoostFactorProvider $boostFactorProvider;
 
     public function __construct(
         ContentTypeHandler $contentTypeHandler,
@@ -55,12 +45,15 @@ class BlockDocumentsContentFields extends ContentTranslationFieldMapper
         $this->boostFactorProvider = $boostFactorProvider;
     }
 
-    public function accept(Content $content, $languageCode)
+    public function accept(Content $content, $languageCode): bool
     {
         return true;
     }
 
-    public function mapFields(Content $content, $languageCode)
+    /**
+     * @return \Ibexa\Contracts\Core\Search\Field[]
+     */
+    public function mapFields(Content $content, $languageCode): array
     {
         $fields = [];
         $contentType = $this->contentTypeHandler->load(
@@ -114,8 +107,8 @@ class BlockDocumentsContentFields extends ContentTranslationFieldMapper
         ContentType $contentType,
         FieldDefinition $fieldDefinition,
         FieldType $fieldType
-    ) {
-        if (!$fieldType instanceof FieldType\TextField) {
+    ): FieldType|TextField {
+        if (!$fieldType instanceof TextField) {
             return $fieldType;
         }
 

--- a/src/lib/FieldMapper/ContentTranslationFieldMapper/BlockDocumentsMetaFields.php
+++ b/src/lib/FieldMapper/ContentTranslationFieldMapper/BlockDocumentsMetaFields.php
@@ -17,12 +17,12 @@ use Ibexa\Contracts\Solr\FieldMapper\ContentTranslationFieldMapper;
  */
 class BlockDocumentsMetaFields extends ContentTranslationFieldMapper
 {
-    public function accept(Content $content, $languageCode)
+    public function accept(Content $content, $languageCode): bool
     {
         return true;
     }
 
-    public function mapFields(Content $content, $languageCode)
+    public function mapFields(Content $content, $languageCode): array
     {
         return [
             new Field(

--- a/src/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentEmptyFields.php
+++ b/src/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentEmptyFields.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Solr\FieldMapper\ContentTranslationFieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content;
+use Ibexa\Contracts\Core\Persistence\Content\Type\Handler;
 use Ibexa\Contracts\Core\Persistence\Content\Type\Handler as ContentTypeHandler;
 use Ibexa\Contracts\Core\Search\Field;
 use Ibexa\Contracts\Core\Search\FieldType;
@@ -23,20 +24,11 @@ class ContentDocumentEmptyFields extends ContentTranslationFieldMapper
 {
     public const IS_EMPTY_NAME = 'is_empty';
 
-    /**
-     * @var \Ibexa\Contracts\Core\Persistence\Content\Type\Handler
-     */
-    private $contentTypeHandler;
+    private Handler $contentTypeHandler;
 
-    /**
-     * @var \Ibexa\Core\Search\Common\FieldNameGenerator
-     */
-    private $fieldNameGenerator;
+    private FieldNameGenerator $fieldNameGenerator;
 
-    /**
-     * @var \Ibexa\Core\Persistence\FieldTypeRegistry
-     */
-    private $fieldTypeRegistry;
+    private FieldTypeRegistry $fieldTypeRegistry;
 
     public function __construct(
         ContentTypeHandler $contentTypeHandler,
@@ -53,7 +45,7 @@ class ContentDocumentEmptyFields extends ContentTranslationFieldMapper
      *
      * @return bool
      */
-    public function accept(Content $content, $languageCode)
+    public function accept(Content $content, $languageCode): bool
     {
         return true;
     }
@@ -63,7 +55,7 @@ class ContentDocumentEmptyFields extends ContentTranslationFieldMapper
      *
      * @return \Ibexa\Contracts\Core\Search\Field[]
      */
-    public function mapFields(Content $content, $languageCode)
+    public function mapFields(Content $content, $languageCode): array
     {
         $fields = [];
         $contentType = $this->contentTypeHandler->load(

--- a/src/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentFulltextFields.php
+++ b/src/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentFulltextFields.php
@@ -97,7 +97,7 @@ class ContentDocumentFulltextFields extends ContentTranslationFieldMapper
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
      */
-    private function doMapFields(Content $content, ContentType $contentType, $languageCode, $maxDepth, float|int $depth = 0): array
+    private function doMapFields(Content $content, ContentType $contentType, $languageCode, $maxDepth, int $depth = 0): array
     {
         $fields = [];
 
@@ -153,7 +153,7 @@ class ContentDocumentFulltextFields extends ContentTranslationFieldMapper
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
      */
-    private function doMapRelatedFields(Content $sourceContent, $languageCode, $maxDepth, int|float $depth): array
+    private function doMapRelatedFields(Content $sourceContent, $languageCode, $maxDepth, int $depth): array
     {
         $sourceContentId = $sourceContent->versionInfo->contentInfo->id;
         $relations = $this->contentHandler->loadRelationList(
@@ -200,8 +200,6 @@ class ContentDocumentFulltextFields extends ContentTranslationFieldMapper
 
     /**
      * Return index field type for the given $contentType.
-     *
-     * @return \Ibexa\Contracts\Core\Search\FieldType
      */
     private function getIndexFieldType(ContentType $contentType): TextField
     {

--- a/src/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentFulltextFields.php
+++ b/src/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentFulltextFields.php
@@ -8,11 +8,13 @@
 namespace Ibexa\Solr\FieldMapper\ContentTranslationFieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content;
+use Ibexa\Contracts\Core\Persistence\Content\Handler;
 use Ibexa\Contracts\Core\Persistence\Content\Handler as ContentHandler;
 use Ibexa\Contracts\Core\Persistence\Content\Type as ContentType;
 use Ibexa\Contracts\Core\Persistence\Content\Type\Handler as ContentTypeHandler;
 use Ibexa\Contracts\Core\Search\Field;
 use Ibexa\Contracts\Core\Search\FieldType;
+use Ibexa\Contracts\Core\Search\FieldType\TextField;
 use Ibexa\Contracts\Solr\FieldMapper\ContentTranslationFieldMapper;
 use Ibexa\Core\Search\Common\FieldNameGenerator;
 use Ibexa\Core\Search\Common\FieldRegistry;
@@ -26,47 +28,25 @@ class ContentDocumentFulltextFields extends ContentTranslationFieldMapper
 {
     /**
      * Field name, untyped.
-     *
-     * @var string
      */
-    private static $fieldName = 'meta_content__text';
+    private static string $fieldName = 'meta_content__text';
 
     /**
      * Field of related content name, untyped.
-     *
-     * @var string
      */
-    private static $relatedContentFieldName = 'meta_related_content_%d__text';
+    private static string $relatedContentFieldName = 'meta_related_content_%d__text';
 
-    /**
-     * @var \Ibexa\Contracts\Core\Persistence\Content\Type\Handler
-     */
-    protected $contentTypeHandler;
+    protected ContentTypeHandler $contentTypeHandler;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Persistence\Content\Handler
-     */
-    protected $contentHandler;
+    protected Handler $contentHandler;
 
-    /**
-     * @var \Ibexa\Core\Search\Common\FieldRegistry
-     */
-    protected $fieldRegistry;
+    protected FieldRegistry $fieldRegistry;
 
-    /**
-     * @var \Ibexa\Core\Search\Common\FieldNameGenerator
-     */
-    protected $fieldNameGenerator;
+    protected FieldNameGenerator $fieldNameGenerator;
 
-    /**
-     * @var \Ibexa\Solr\FieldMapper\BoostFactorProvider
-     */
-    protected $boostFactorProvider;
+    protected BoostFactorProvider $boostFactorProvider;
 
-    /**
-     * @var \Ibexa\Solr\FieldMapper\IndexingDepthProvider
-     */
-    protected $indexingDepthProvider;
+    protected IndexingDepthProvider $indexingDepthProvider;
 
     public function __construct(
         ContentTypeHandler $contentTypeHandler,
@@ -87,7 +67,7 @@ class ContentDocumentFulltextFields extends ContentTranslationFieldMapper
     /**
      * {@inheritdoc}
      */
-    public function accept(Content $content, $languageCode)
+    public function accept(Content $content, $languageCode): bool
     {
         return true;
     }
@@ -117,7 +97,7 @@ class ContentDocumentFulltextFields extends ContentTranslationFieldMapper
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
      */
-    private function doMapFields(Content $content, ContentType $contentType, $languageCode, $maxDepth, $depth = 0)
+    private function doMapFields(Content $content, ContentType $contentType, $languageCode, $maxDepth, float|int $depth = 0): array
     {
         $fields = [];
 
@@ -173,7 +153,7 @@ class ContentDocumentFulltextFields extends ContentTranslationFieldMapper
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
      */
-    private function doMapRelatedFields(Content $sourceContent, $languageCode, $maxDepth, $depth)
+    private function doMapRelatedFields(Content $sourceContent, $languageCode, $maxDepth, int|float $depth): array
     {
         $sourceContentId = $sourceContent->versionInfo->contentInfo->id;
         $relations = $this->contentHandler->loadRelationList(
@@ -223,9 +203,9 @@ class ContentDocumentFulltextFields extends ContentTranslationFieldMapper
      *
      * @return \Ibexa\Contracts\Core\Search\FieldType
      */
-    private function getIndexFieldType(ContentType $contentType)
+    private function getIndexFieldType(ContentType $contentType): TextField
     {
-        $newFieldType = new FieldType\TextField();
+        $newFieldType = new TextField();
         $newFieldType->boost = $this->boostFactorProvider->getContentMetaFieldBoostFactor(
             $contentType,
             'text'

--- a/src/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentTranslatedContentNameField.php
+++ b/src/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentTranslatedContentNameField.php
@@ -8,6 +8,7 @@
 namespace Ibexa\Solr\FieldMapper\ContentTranslationFieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Content;
+use Ibexa\Contracts\Core\Persistence\Content\Type\Handler;
 use Ibexa\Contracts\Core\Persistence\Content\Type\Handler as ContentTypeHandler;
 use Ibexa\Contracts\Core\Search\Field;
 use Ibexa\Contracts\Core\Search\FieldType;
@@ -21,20 +22,12 @@ class ContentDocumentTranslatedContentNameField extends ContentTranslationFieldM
 {
     /**
      * Field name, untyped.
-     *
-     * @var string
      */
-    private static $fieldName = 'meta_content__name';
+    private static string $fieldName = 'meta_content__name';
 
-    /**
-     * @var \Ibexa\Contracts\Core\Persistence\Content\Type\Handler
-     */
-    protected $contentTypeHandler;
+    protected Handler $contentTypeHandler;
 
-    /**
-     * @var \Ibexa\Solr\FieldMapper\BoostFactorProvider
-     */
-    protected $boostFactorProvider;
+    protected BoostFactorProvider $boostFactorProvider;
 
     public function __construct(
         ContentTypeHandler $contentTypeHandler,
@@ -44,12 +37,12 @@ class ContentDocumentTranslatedContentNameField extends ContentTranslationFieldM
         $this->boostFactorProvider = $boostFactorProvider;
     }
 
-    public function accept(Content $content, $languageCode)
+    public function accept(Content $content, $languageCode): bool
     {
         return true;
     }
 
-    public function mapFields(Content $content, $languageCode)
+    public function mapFields(Content $content, $languageCode): array
     {
         if (!isset($content->versionInfo->names[$languageCode])) {
             return [];

--- a/src/lib/FieldMapper/IndexingDepthProvider.php
+++ b/src/lib/FieldMapper/IndexingDepthProvider.php
@@ -12,10 +12,7 @@ use Ibexa\Contracts\Core\Persistence\Content\Type as ContentType;
 
 class IndexingDepthProvider
 {
-    /**
-     * @var array
-     */
-    private $contentTypeMap;
+    private array $contentTypeMap;
 
     /**
      * @var int

--- a/src/lib/FieldMapper/LocationFieldMapper/Aggregate.php
+++ b/src/lib/FieldMapper/LocationFieldMapper/Aggregate.php
@@ -36,17 +36,20 @@ class Aggregate extends LocationFieldMapper
     /**
      * Adds given $mapper to the internal array as the next one in priority.
      */
-    public function addMapper(LocationFieldMapper $mapper)
+    public function addMapper(LocationFieldMapper $mapper): void
     {
         $this->mappers[] = $mapper;
     }
 
-    public function accept(Location $location)
+    public function accept(Location $location): bool
     {
         return true;
     }
 
-    public function mapFields(Location $location)
+    /**
+     * @return mixed[]
+     */
+    public function mapFields(Location $location): array
     {
         $fields = [];
 

--- a/src/lib/FieldMapper/LocationFieldMapper/LocationDocumentBaseFields.php
+++ b/src/lib/FieldMapper/LocationFieldMapper/LocationDocumentBaseFields.php
@@ -8,6 +8,7 @@
 namespace Ibexa\Solr\FieldMapper\LocationFieldMapper;
 
 use Ibexa\Contracts\Core\Persistence\Bookmark\Handler as BookmarkHandler;
+use Ibexa\Contracts\Core\Persistence\Content\Handler;
 use Ibexa\Contracts\Core\Persistence\Content\Handler as ContentHandler;
 use Ibexa\Contracts\Core\Persistence\Content\Location;
 use Ibexa\Contracts\Core\Persistence\Content\Type\Handler as ContentTypeHandler;
@@ -21,10 +22,7 @@ use Ibexa\Contracts\Solr\FieldMapper\LocationFieldMapper;
  */
 class LocationDocumentBaseFields extends LocationFieldMapper
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Persistence\Content\Handler
-     */
-    protected $contentHandler;
+    protected Handler $contentHandler;
 
     protected ContentTypeHandler $contentTypeHandler;
 
@@ -40,12 +38,12 @@ class LocationDocumentBaseFields extends LocationFieldMapper
         $this->contentTypeHandler = $contentTypeHandler;
     }
 
-    public function accept(Location $location)
+    public function accept(Location $location): bool
     {
         return true;
     }
 
-    public function mapFields(Location $location)
+    public function mapFields(Location $location): array
     {
         $contentInfo = $this->contentHandler->loadContentInfo($location->contentId);
         $contentType = $this->contentTypeHandler->load($contentInfo->contentTypeId);

--- a/src/lib/Gateway/DistributionStrategy/AbstractDistributionStrategy.php
+++ b/src/lib/Gateway/DistributionStrategy/AbstractDistributionStrategy.php
@@ -17,15 +17,10 @@ abstract class AbstractDistributionStrategy implements DistributionStrategy
 {
     /**
      * Endpoint registry service.
-     *
-     * @var \Ibexa\Solr\Gateway\EndpointRegistry
      */
-    protected $endpointRegistry;
+    protected EndpointRegistry $endpointRegistry;
 
-    /**
-     * @var \Ibexa\Solr\Gateway\EndpointResolver
-     */
-    protected $endpointResolver;
+    protected EndpointResolver $endpointResolver;
 
     public function __construct(EndpointRegistry $endpointRegistry, EndpointResolver $endpointResolver)
     {

--- a/src/lib/Gateway/Endpoint.php
+++ b/src/lib/Gateway/Endpoint.php
@@ -94,7 +94,7 @@ class Endpoint extends ValueObject
      *
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return "{$this->host}:{$this->port}{$this->path}/{$this->core}";
     }
@@ -104,7 +104,7 @@ class Endpoint extends ValueObject
      *
      * @return string
      */
-    public function getURL()
+    public function getURL(): string
     {
         $authorization = (!empty($this->user) ? "{$this->user}:{$this->pass}@" : '');
 

--- a/src/lib/Gateway/EndpointRegistry.php
+++ b/src/lib/Gateway/EndpointRegistry.php
@@ -39,7 +39,7 @@ class EndpointRegistry
      * @param string $name
      * @param \Ibexa\Solr\Gateway\Endpoint $endpoint
      */
-    public function registerEndpoint($name, Endpoint $endpoint)
+    public function registerEndpoint($name, Endpoint $endpoint): void
     {
         $this->endpoint[$name] = $endpoint;
     }
@@ -65,7 +65,7 @@ class EndpointRegistry
      *
      * @return \Ibexa\Solr\Gateway\Endpoint
      */
-    public function getFirstEndpoint()
+    public function getFirstEndpoint(): Endpoint
     {
         if (empty($this->endpoint)) {
             throw new OutOfBoundsException("No Endpoint registered at all'.");

--- a/src/lib/Gateway/EndpointResolver/NativeEndpointResolver.php
+++ b/src/lib/Gateway/EndpointResolver/NativeEndpointResolver.php
@@ -21,7 +21,7 @@ class NativeEndpointResolver implements EndpointResolver, SingleEndpointResolver
      *
      * @var string[]
      */
-    private $entryEndpoints;
+    private array $entryEndpoints;
 
     /**
      * Holds a map of translations to Endpoint names, with language code as key
@@ -36,7 +36,7 @@ class NativeEndpointResolver implements EndpointResolver, SingleEndpointResolver
      *
      * @var string[]
      */
-    private $endpointMap;
+    private array $endpointMap;
 
     /**
      * Holds a name of the default Endpoint used for translations, if configured.
@@ -79,7 +79,7 @@ class NativeEndpointResolver implements EndpointResolver, SingleEndpointResolver
         $this->mainLanguagesEndpoint = $mainLanguagesEndpoint;
     }
 
-    public function getEntryEndpoint()
+    public function getEntryEndpoint(): string
     {
         if (empty($this->entryEndpoints)) {
             throw new RuntimeException('No entry endpoints defined');

--- a/src/lib/Gateway/GatewayRegistry.php
+++ b/src/lib/Gateway/GatewayRegistry.php
@@ -16,7 +16,7 @@ use OutOfBoundsException;
 final class GatewayRegistry
 {
     /** @var \Ibexa\Solr\Gateway[] */
-    private $gateways;
+    private array $gateways;
 
     /**
      * @param \Ibexa\Solr\Gateway[] $gateways

--- a/src/lib/Gateway/HttpClient/Stream.php
+++ b/src/lib/Gateway/HttpClient/Stream.php
@@ -25,11 +25,9 @@ class Stream implements HttpClient, LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
-    /** @var int */
-    private $connectionTimeout;
+    private int $connectionTimeout;
 
-    /** @var \Symfony\Contracts\HttpClient\HttpClientInterface */
-    private $client;
+    private HttpClientInterface $client;
 
     /**
      * @param int $timeout Timeout for connection in seconds.
@@ -74,9 +72,9 @@ class Stream implements HttpClient, LoggerAwareInterface
      * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
      */
     private function getResponseMessage(
-        $method,
+        string $method,
         Endpoint $endpoint,
-        $path,
+        string $path,
         Message $message
     ): Message {
         if ($endpoint->user !== null) {

--- a/src/lib/Gateway/Native.php
+++ b/src/lib/Gateway/Native.php
@@ -125,10 +125,8 @@ class Native extends Gateway
      *
      * Array markers, possibly added for the facet parameters,
      * will be removed from the result.
-     *
-     * @return string
      */
-    protected function generateQueryString(array $parameters): string|array
+    protected function generateQueryString(array $parameters): string
     {
         $removedArrayCharacters = preg_replace(
             '/%5B[0-9]+%5D=/',
@@ -136,9 +134,7 @@ class Native extends Gateway
             http_build_query($parameters)
         );
 
-        $removedDuplicatedEscapingForUrlPath = str_replace('%5C%5C%2F', '%5C%2F', $removedArrayCharacters);
-
-        return $removedDuplicatedEscapingForUrlPath;
+        return str_replace('%5C%5C%2F', '%5C%2F', $removedArrayCharacters);
     }
 
     /**

--- a/src/lib/Gateway/Native.php
+++ b/src/lib/Gateway/Native.php
@@ -23,46 +23,29 @@ class Native extends Gateway
 {
     /**
      * HTTP client to communicate with Solr server.
-     *
-     * @var \Ibexa\Solr\Gateway\HttpClient
      */
-    protected $client;
+    protected HttpClient $client;
 
-    /**
-     * @var \Ibexa\Solr\Gateway\EndpointResolver
-     */
-    protected $endpointResolver;
+    protected EndpointResolver $endpointResolver;
 
     /**
      * Endpoint registry service.
-     *
-     * @var \Ibexa\Solr\Gateway\EndpointRegistry
      */
-    protected $endpointRegistry;
+    protected EndpointRegistry $endpointRegistry;
 
     /**
      * Content Query converter.
-     *
-     * @var \Ibexa\Solr\Query\QueryConverter
      */
-    protected $contentQueryConverter;
+    protected QueryConverter $contentQueryConverter;
 
     /**
      * Location Query converter.
-     *
-     * @var \Ibexa\Solr\Query\QueryConverter
      */
-    protected $locationQueryConverter;
+    protected QueryConverter $locationQueryConverter;
 
-    /**
-     * @var \Ibexa\Solr\Gateway\UpdateSerializerInterface
-     */
-    protected $updateSerializer;
+    protected UpdateSerializerInterface $updateSerializer;
 
-    /**
-     * @var \Ibexa\Solr\Gateway\DistributionStrategy
-     */
-    protected $distributionStrategy;
+    protected DistributionStrategy $distributionStrategy;
 
     public function __construct(
         HttpClient $client,
@@ -145,7 +128,7 @@ class Native extends Gateway
      *
      * @return string
      */
-    protected function generateQueryString(array $parameters)
+    protected function generateQueryString(array $parameters): string|array
     {
         $removedArrayCharacters = preg_replace(
             '/%5B[0-9]+%5D=/',
@@ -167,7 +150,7 @@ class Native extends Gateway
      *
      * @return string
      */
-    protected function getSearchTargets($languageSettings)
+    protected function getSearchTargets(array $languageSettings): string
     {
         if ($this->endpointResolver instanceof SingleEndpointResolver && !$this->endpointResolver->hasMultipleEndpoints()) {
             return '';
@@ -192,7 +175,7 @@ class Native extends Gateway
      *
      * @return string
      */
-    protected function getAllSearchTargets()
+    protected function getAllSearchTargets(): string
     {
         if ($this->endpointResolver instanceof SingleEndpointResolver && !$this->endpointResolver->hasMultipleEndpoints()) {
             return '';
@@ -323,7 +306,7 @@ class Native extends Gateway
      *
      * @param string $query
      */
-    public function deleteByQuery($query)
+    public function deleteByQuery($query): void
     {
         $endpoints = $this->endpointResolver->getEndpoints();
 
@@ -347,7 +330,7 @@ class Native extends Gateway
      *
      * Purges all contents from the index
      */
-    public function purgeIndex()
+    public function purgeIndex(): void
     {
         $endpoints = $this->endpointResolver->getEndpoints();
 
@@ -363,7 +346,7 @@ class Native extends Gateway
      *
      * @todo error handling
      */
-    protected function purgeEndpoint($endpoint)
+    protected function purgeEndpoint(Endpoint $endpoint)
     {
         $this->client->request(
             'POST',
@@ -387,7 +370,7 @@ class Native extends Gateway
      *
      * @param bool $flush
      */
-    public function commit($flush = false)
+    public function commit($flush = false): void
     {
         $payload = $flush ?
             '<commit/>' :

--- a/src/lib/Gateway/UpdateSerializer/UpdateSerializer.php
+++ b/src/lib/Gateway/UpdateSerializer/UpdateSerializer.php
@@ -19,11 +19,9 @@ use Ibexa\Core\Search\Common\FieldValueMapper;
  */
 abstract class UpdateSerializer
 {
-    /** @var \Ibexa\Core\Search\Common\FieldValueMapper */
-    protected $fieldValueMapper;
+    protected FieldValueMapper $fieldValueMapper;
 
-    /** @var \Ibexa\Core\Search\Common\FieldNameGenerator */
-    protected $nameGenerator;
+    protected FieldNameGenerator $nameGenerator;
 
     public function __construct(
         FieldValueMapper $fieldValueMapper,

--- a/src/lib/Gateway/UpdateSerializerFactory.php
+++ b/src/lib/Gateway/UpdateSerializerFactory.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Core\Exception\InvalidArgumentException;
 class UpdateSerializerFactory
 {
     /** @var \Ibexa\Solr\Gateway\UpdateSerializerInterface[]|iterable */
-    private $serializers;
+    private iterable $serializers;
 
     /**
      * @param iterable<\Ibexa\Solr\Gateway\UpdateSerializerInterface> $serializers

--- a/src/lib/Handler.php
+++ b/src/lib/Handler.php
@@ -14,6 +14,7 @@ use Ibexa\Contracts\Core\Repository\SearchService;
 use Ibexa\Contracts\Core\Repository\Values\Content\LocationQuery;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\CustomField;
 use Ibexa\Contracts\Core\Repository\Values\Content\Search\SearchResult;
 use Ibexa\Contracts\Core\Search\VersatileHandler;
 use Ibexa\Contracts\Solr\DocumentMapper;
@@ -51,45 +52,33 @@ class Handler implements VersatileHandler
 
     /**
      * Content locator gateway.
-     *
-     * @var \Ibexa\Solr\Gateway
      */
-    protected $gateway;
+    protected Gateway $gateway;
 
     /**
      * Content handler.
-     *
-     * @var \Ibexa\Contracts\Core\Persistence\Content\Handler
      */
-    protected $contentHandler;
+    protected ContentHandler $contentHandler;
 
     /**
      * Document mapper.
-     *
-     * @var \Ibexa\Contracts\Solr\DocumentMapper
      */
-    protected $mapper;
+    protected DocumentMapper $mapper;
 
     /**
      * Content result extractor.
-     *
-     * @var \Ibexa\Solr\ResultExtractor
      */
-    protected $contentResultExtractor;
+    protected ResultExtractor $contentResultExtractor;
 
     /**
      * Location result extractor.
-     *
-     * @var \Ibexa\Solr\ResultExtractor
      */
-    protected $locationResultExtractor;
+    protected ResultExtractor $locationResultExtractor;
 
     /**
      * Core filter service.
-     *
-     * @var \Ibexa\Solr\CoreFilter
      */
-    protected $coreFilter;
+    protected CoreFilter $coreFilter;
 
     /**
      * Creates a new content handler.
@@ -202,7 +191,7 @@ class Handler implements VersatileHandler
     /**
      * Indexes a content object.
      */
-    public function indexContent(Content $content)
+    public function indexContent(Content $content): void
     {
         $this->gateway->bulkIndexDocuments([$this->mapper->mapContentBlock($content)]);
     }
@@ -224,7 +213,7 @@ class Handler implements VersatileHandler
      *
      * @param \Ibexa\Contracts\Core\Persistence\Content[] $contentObjects
      */
-    public function bulkIndexContent(array $contentObjects)
+    public function bulkIndexContent(array $contentObjects): void
     {
         $documents = [];
 
@@ -244,7 +233,7 @@ class Handler implements VersatileHandler
     /**
      * Indexes a Location in the index storage.
      */
-    public function indexLocation(Location $location)
+    public function indexLocation(Location $location): void
     {
         // Does nothing: in this implementation Locations are indexed as
         //               a part of Content document block
@@ -256,7 +245,7 @@ class Handler implements VersatileHandler
      * @param int $contentId
      * @param int|null $versionId
      */
-    public function deleteContent($contentId, $versionId = null)
+    public function deleteContent($contentId, $versionId = null): void
     {
         $idPrefix = $this->mapper->generateContentDocumentId($contentId);
 
@@ -269,7 +258,7 @@ class Handler implements VersatileHandler
      * @param mixed $locationId
      * @param mixed $contentId
      */
-    public function deleteLocation($locationId, $contentId)
+    public function deleteLocation($locationId, $contentId): void
     {
         $this->deleteAllItemsWithoutAdditionalLocation($locationId);
         $this->updateAllElementsWithAdditionalLocation($locationId);
@@ -278,7 +267,7 @@ class Handler implements VersatileHandler
     /**
      * Purges all contents from the index.
      */
-    public function purgeIndex()
+    public function purgeIndex(): void
     {
         $this->gateway->purgeIndex();
     }
@@ -294,7 +283,7 @@ class Handler implements VersatileHandler
      *
      * @param bool $flush
      */
-    public function commit($flush = false)
+    public function commit($flush = false): void
     {
         $this->gateway->commit($flush);
     }
@@ -366,7 +355,7 @@ class Handler implements VersatileHandler
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query
      */
-    protected function prepareQuery($limit = self::DEFAULT_QUERY_LIMIT)
+    protected function prepareQuery($limit = self::DEFAULT_QUERY_LIMIT): Query
     {
         return new Query(
             [
@@ -380,11 +369,11 @@ class Handler implements VersatileHandler
     /**
      * @param int $locationId
      *
-     * @return Criterion\CustomField
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\CustomField
      */
-    protected function allItemsWithinLocation($locationId)
+    protected function allItemsWithinLocation($locationId): CustomField
     {
-        return new Criterion\CustomField(
+        return new CustomField(
             'location_path_string_mid',
             Criterion\Operator::EQ,
             "/.*\\/{$locationId}\\/.*/"
@@ -394,11 +383,11 @@ class Handler implements VersatileHandler
     /**
      * @param int $locationId
      *
-     * @return Criterion\CustomField
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\CustomField
      */
-    protected function allItemsWithinLocationWithAdditionalLocation($locationId)
+    protected function allItemsWithinLocationWithAdditionalLocation($locationId): CustomField
     {
-        return new Criterion\CustomField(
+        return new CustomField(
             'location_path_string_mid',
             Criterion\Operator::EQ,
             "/@&~(.*\\/{$locationId}\\/.*)/"
@@ -425,7 +414,7 @@ class Handler implements VersatileHandler
      *
      * @param \Ibexa\Contracts\Core\Search\Document[] $documents
      */
-    public function bulkIndexDocuments(array $documents)
+    public function bulkIndexDocuments(array $documents): void
     {
         $this->gateway->bulkIndexDocuments($documents);
     }

--- a/src/lib/Indexer.php
+++ b/src/lib/Indexer.php
@@ -37,12 +37,12 @@ class Indexer extends IncrementalIndexer
         return 'Ibexa Solr Search Engine';
     }
 
-    public function purge()
+    public function purge(): void
     {
         $this->searchHandler->purgeIndex();
     }
 
-    public function updateSearchIndex(array $contentIds, $commit)
+    public function updateSearchIndex(array $contentIds, $commit): void
     {
         $documents = [];
         $contentHandler = $this->persistenceHandler->contentHandler();

--- a/src/lib/Query/Common/AggregationVisitor/AggregationFieldResolver/ContentFieldAggregationFieldResolver.php
+++ b/src/lib/Query/Common/AggregationVisitor/AggregationFieldResolver/ContentFieldAggregationFieldResolver.php
@@ -16,11 +16,9 @@ use RuntimeException;
 
 final class ContentFieldAggregationFieldResolver implements AggregationFieldResolver
 {
-    /** @var \Ibexa\Core\Search\Common\FieldNameResolver */
-    private $fieldNameResolver;
+    private FieldNameResolver $fieldNameResolver;
 
-    /** @var string */
-    private $searchFieldName;
+    private string $searchFieldName;
 
     public function __construct(FieldNameResolver $fieldNameResolver, string $searchFieldName)
     {

--- a/src/lib/Query/Common/AggregationVisitor/AggregationFieldResolver/SearchFieldAggregationFieldResolver.php
+++ b/src/lib/Query/Common/AggregationVisitor/AggregationFieldResolver/SearchFieldAggregationFieldResolver.php
@@ -13,8 +13,7 @@ use Ibexa\Contracts\Solr\Query\Common\AggregationVisitor\AggregationFieldResolve
 
 final class SearchFieldAggregationFieldResolver implements AggregationFieldResolver
 {
-    /** @var string */
-    private $searchIndexFieldName;
+    private string $searchIndexFieldName;
 
     public function __construct(string $searchIndexFieldName)
     {

--- a/src/lib/Query/Common/AggregationVisitor/DispatcherAggregationVisitor.php
+++ b/src/lib/Query/Common/AggregationVisitor/DispatcherAggregationVisitor.php
@@ -15,7 +15,7 @@ use Ibexa\Contracts\Solr\Query\AggregationVisitor;
 final class DispatcherAggregationVisitor implements AggregationVisitor
 {
     /** @var iterable<\Ibexa\Contracts\Solr\Query\AggregationVisitor> */
-    private $visitors;
+    private iterable $visitors;
 
     /**
      * @param iterable<\Ibexa\Contracts\Solr\Query\AggregationVisitor> $visitors

--- a/src/lib/Query/Common/AggregationVisitor/Factory/ContentFieldAggregationVisitorFactory.php
+++ b/src/lib/Query/Common/AggregationVisitor/Factory/ContentFieldAggregationVisitorFactory.php
@@ -17,8 +17,7 @@ use Ibexa\Solr\Query\Common\AggregationVisitor\TermAggregationVisitor;
 
 final class ContentFieldAggregationVisitorFactory
 {
-    /** @var \Ibexa\Core\Search\Common\FieldNameResolver */
-    private $fieldNameResolver;
+    private FieldNameResolver $fieldNameResolver;
 
     public function __construct(FieldNameResolver $fieldNameResolver)
     {

--- a/src/lib/Query/Common/AggregationVisitor/RangeAggregationVisitor.php
+++ b/src/lib/Query/Common/AggregationVisitor/RangeAggregationVisitor.php
@@ -14,11 +14,9 @@ use Ibexa\Contracts\Solr\Query\Common\AggregationVisitor\AggregationFieldResolve
 
 final class RangeAggregationVisitor extends AbstractRangeAggregationVisitor
 {
-    /** @var string */
-    private $aggregationClass;
+    private string $aggregationClass;
 
-    /** @var \Ibexa\Contracts\Solr\Query\Common\AggregationVisitor\AggregationFieldResolver */
-    private $aggregationFieldResolver;
+    private AggregationFieldResolver $aggregationFieldResolver;
 
     public function __construct(string $aggregationClass, AggregationFieldResolver $aggregationFieldResolver)
     {

--- a/src/lib/Query/Common/AggregationVisitor/StatsAggregationVisitor.php
+++ b/src/lib/Query/Common/AggregationVisitor/StatsAggregationVisitor.php
@@ -14,11 +14,9 @@ use Ibexa\Contracts\Solr\Query\Common\AggregationVisitor\AggregationFieldResolve
 
 final class StatsAggregationVisitor extends AbstractStatsAggregationVisitor
 {
-    /** @var string */
-    private $aggregationClass;
+    private string $aggregationClass;
 
-    /** @var \Ibexa\Contracts\Solr\Query\Common\AggregationVisitor\AggregationFieldResolver */
-    private $aggregationFieldResolver;
+    private AggregationFieldResolver $aggregationFieldResolver;
 
     public function __construct(string $aggregationClass, AggregationFieldResolver $aggregationFieldResolver)
     {

--- a/src/lib/Query/Common/AggregationVisitor/SubtreeTermAggregationVisitor.php
+++ b/src/lib/Query/Common/AggregationVisitor/SubtreeTermAggregationVisitor.php
@@ -14,11 +14,9 @@ use Ibexa\Contracts\Solr\Query\AggregationVisitor;
 
 final class SubtreeTermAggregationVisitor implements AggregationVisitor
 {
-    /** @var string */
-    private $pathStringFieldName;
+    private string $pathStringFieldName;
 
-    /** @var string */
-    private $locationIdFieldName;
+    private string $locationIdFieldName;
 
     public function __construct(string $pathStringFieldName, string $locationIdFieldName)
     {

--- a/src/lib/Query/Common/AggregationVisitor/TermAggregationVisitor.php
+++ b/src/lib/Query/Common/AggregationVisitor/TermAggregationVisitor.php
@@ -14,11 +14,9 @@ use Ibexa\Contracts\Solr\Query\Common\AggregationVisitor\AggregationFieldResolve
 
 final class TermAggregationVisitor extends AbstractTermAggregationVisitor
 {
-    /** @var string */
-    private $aggregationClass;
+    private string $aggregationClass;
 
-    /** @var \Ibexa\Contracts\Solr\Query\Common\AggregationVisitor\AggregationFieldResolver */
-    private $aggregationFieldResolver;
+    private AggregationFieldResolver $aggregationFieldResolver;
 
     public function __construct(string $aggregationClass, AggregationFieldResolver $aggregationFieldResolver)
     {

--- a/src/lib/Query/Common/CriterionVisitor/Aggregate.php
+++ b/src/lib/Query/Common/CriterionVisitor/Aggregate.php
@@ -39,7 +39,7 @@ class Aggregate extends CriterionVisitor
     /**
      * Adds visitor.
      */
-    public function addVisitor(CriterionVisitor $visitor)
+    public function addVisitor(CriterionVisitor $visitor): void
     {
         $this->visitors[] = $visitor;
     }
@@ -49,7 +49,7 @@ class Aggregate extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return true;
     }

--- a/src/lib/Query/Common/CriterionVisitor/ContentIdIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/ContentIdIn.php
@@ -46,7 +46,7 @@ class ContentIdIn extends CriterionVisitor
             implode(
                 ' OR ',
                 array_map(
-                    static function (string $value): string {
+                    static function (bool|float|int|string $value): string {
                         return 'content_id_id:"' . $value . '"';
                     },
                     $criterion->value

--- a/src/lib/Query/Common/CriterionVisitor/ContentIdIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/ContentIdIn.php
@@ -22,7 +22,7 @@ class ContentIdIn extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\ContentId &&
@@ -40,13 +40,13 @@ class ContentIdIn extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         return '(' .
             implode(
                 ' OR ',
                 array_map(
-                    static function ($value) {
+                    static function (string $value): string {
                         return 'content_id_id:"' . $value . '"';
                     },
                     $criterion->value

--- a/src/lib/Query/Common/CriterionVisitor/ContentTypeGroupIdIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/ContentTypeGroupIdIn.php
@@ -22,7 +22,7 @@ class ContentTypeGroupIdIn extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\ContentTypeGroupId &&
@@ -40,13 +40,13 @@ class ContentTypeGroupIdIn extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         return '(' .
             implode(
                 ' OR ',
                 array_map(
-                    static function ($value) {
+                    static function (string $value): string {
                         return 'content_type_group_ids_mid:"' . $value . '"';
                     },
                     // TODO this should have been casted by criterion???

--- a/src/lib/Query/Common/CriterionVisitor/ContentTypeGroupIdIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/ContentTypeGroupIdIn.php
@@ -46,7 +46,7 @@ class ContentTypeGroupIdIn extends CriterionVisitor
             implode(
                 ' OR ',
                 array_map(
-                    static function (string $value): string {
+                    static function (bool|float|int|string $value): string {
                         return 'content_type_group_ids_mid:"' . $value . '"';
                     },
                     // TODO this should have been casted by criterion???

--- a/src/lib/Query/Common/CriterionVisitor/ContentTypeIdIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/ContentTypeIdIn.php
@@ -46,7 +46,7 @@ class ContentTypeIdIn extends CriterionVisitor
             implode(
                 ' OR ',
                 array_map(
-                    static function (string $value): string {
+                    static function (bool|float|int|string $value): string {
                         return 'content_type_id_id:"' . $value . '"';
                     },
                     $criterion->value

--- a/src/lib/Query/Common/CriterionVisitor/ContentTypeIdIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/ContentTypeIdIn.php
@@ -22,7 +22,7 @@ class ContentTypeIdIn extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\ContentTypeId &&
@@ -40,13 +40,13 @@ class ContentTypeIdIn extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         return '(' .
             implode(
                 ' OR ',
                 array_map(
-                    static function ($value) {
+                    static function (string $value): string {
                         return 'content_type_id_id:"' . $value . '"';
                     },
                     $criterion->value

--- a/src/lib/Query/Common/CriterionVisitor/ContentTypeIdentifierIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/ContentTypeIdentifierIn.php
@@ -23,15 +23,10 @@ class ContentTypeIdentifierIn extends CriterionVisitor
 {
     /**
      * ContentType handler.
-     *
-     * @var \Ibexa\Contracts\Core\Persistence\Content\Type\Handler
      */
-    protected $contentTypeHandler;
+    protected Handler $contentTypeHandler;
 
-    /**
-     * @var \Psr\Log\LoggerInterface
-     */
-    protected $logger;
+    protected LoggerInterface $logger;
 
     /**
      * Create from content type handler and field registry.
@@ -47,7 +42,7 @@ class ContentTypeIdentifierIn extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\ContentTypeIdentifier
@@ -65,7 +60,7 @@ class ContentTypeIdentifierIn extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         $validIds = [];
         $invalidIdentifiers = [];
@@ -97,7 +92,7 @@ class ContentTypeIdentifierIn extends CriterionVisitor
             implode(
                 ' OR ',
                 array_map(
-                    static function ($value) {
+                    static function (string $value): string {
                         return 'content_type_id_id:"' . $value . '"';
                     },
                     $validIds

--- a/src/lib/Query/Common/CriterionVisitor/CustomField/CustomFieldIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/CustomField/CustomFieldIn.php
@@ -22,7 +22,7 @@ class CustomFieldIn extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\CustomField &&
@@ -41,7 +41,7 @@ class CustomFieldIn extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         $queries = [];
         $values = (array)$criterion->value;
@@ -59,7 +59,7 @@ class CustomFieldIn extends CriterionVisitor
         return '(' . implode(' OR ', $queries) . ')';
     }
 
-    private function isRegExp($preparedValue)
+    private function isRegExp($preparedValue): int|false
     {
         return preg_match('#^/.*/$#', $preparedValue);
     }

--- a/src/lib/Query/Common/CriterionVisitor/CustomField/CustomFieldRange.php
+++ b/src/lib/Query/Common/CriterionVisitor/CustomField/CustomFieldRange.php
@@ -22,7 +22,7 @@ class CustomFieldRange extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\CustomField &&
@@ -43,7 +43,7 @@ class CustomFieldRange extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         $values = (array)$criterion->value;
         $start = $values[0];

--- a/src/lib/Query/Common/CriterionVisitor/DateMetadata/ModifiedBetween.php
+++ b/src/lib/Query/Common/CriterionVisitor/DateMetadata/ModifiedBetween.php
@@ -23,7 +23,7 @@ class ModifiedBetween extends DateMetadata
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\DateMetadata &&
@@ -43,7 +43,7 @@ class ModifiedBetween extends DateMetadata
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         $start = $this->getSolrTime($criterion->value[0]);
         $end = isset($criterion->value[1]) ? $this->getSolrTime($criterion->value[1]) : null;

--- a/src/lib/Query/Common/CriterionVisitor/DateMetadata/ModifiedIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/DateMetadata/ModifiedIn.php
@@ -23,7 +23,7 @@ class ModifiedIn extends DateMetadata
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\DateMetadata &&
@@ -42,7 +42,7 @@ class ModifiedIn extends DateMetadata
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         $values = [];
         foreach ($criterion->value as $value) {

--- a/src/lib/Query/Common/CriterionVisitor/DateMetadata/PublishedBetween.php
+++ b/src/lib/Query/Common/CriterionVisitor/DateMetadata/PublishedBetween.php
@@ -50,7 +50,7 @@ class PublishedBetween extends DateMetadata
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         $start = $this->getSolrTime($criterion->value[0]);
         $end = isset($criterion->value[1]) ? $this->getSolrTime($criterion->value[1]) : null;

--- a/src/lib/Query/Common/CriterionVisitor/DateMetadata/PublishedIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/DateMetadata/PublishedIn.php
@@ -46,12 +46,12 @@ class PublishedIn extends DateMetadata
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         return implode(
             ' OR ',
             array_map(
-                function ($value) {
+                function ($value): string {
                     return 'content_publication_date_dt:"' . $this->getSolrTime($value) . '"';
                 },
                 $criterion->value

--- a/src/lib/Query/Common/CriterionVisitor/Factory/FullTextFactoryAbstract.php
+++ b/src/lib/Query/Common/CriterionVisitor/Factory/FullTextFactoryAbstract.php
@@ -27,30 +27,16 @@ abstract class FullTextFactoryAbstract
 {
     /**
      * Field map.
-     *
-     * @var \Ibexa\Core\Search\Common\FieldNameResolver
      */
-    protected $fieldNameResolver;
+    protected FieldNameResolver $fieldNameResolver;
 
-    /**
-     * @var \QueryTranslator\Languages\Galach\Tokenizer
-     */
-    protected $tokenizer;
+    protected Tokenizer $tokenizer;
 
-    /**
-     * @var \QueryTranslator\Languages\Galach\Parser
-     */
-    protected $parser;
+    protected Parser $parser;
 
-    /**
-     * @var \QueryTranslator\Languages\Galach\Generators\ExtendedDisMax
-     */
-    protected $generator;
+    protected ExtendedDisMax $generator;
 
-    /**
-     * @var \Ibexa\Solr\FieldMapper\IndexingDepthProvider
-     */
-    protected $indexingDepthProvider;
+    protected IndexingDepthProvider $indexingDepthProvider;
 
     /**
      * Create from content type handler and field registry.

--- a/src/lib/Query/Common/CriterionVisitor/Field.php
+++ b/src/lib/Query/Common/CriterionVisitor/Field.php
@@ -23,15 +23,10 @@ abstract class Field extends CriterionVisitor
 {
     /**
      * Field map.
-     *
-     * @var \Ibexa\Core\Search\Common\FieldNameResolver
      */
-    protected $fieldNameResolver;
+    protected FieldNameResolver $fieldNameResolver;
 
-    /**
-     * @var \Ibexa\Core\Search\Common\FieldValueMapper
-     */
-    protected $fieldValueMapper;
+    protected FieldValueMapper $fieldValueMapper;
 
     public function __construct(FieldNameResolver $fieldNameResolver, FieldValueMapper $fieldValueMapper)
     {

--- a/src/lib/Query/Common/CriterionVisitor/Field/FieldEmpty.php
+++ b/src/lib/Query/Common/CriterionVisitor/Field/FieldEmpty.php
@@ -24,10 +24,7 @@ use Ibexa\Solr\Query\Common\CriterionVisitor\Field;
  */
 final class FieldEmpty extends Field
 {
-    /**
-     * @var \Ibexa\Core\Search\Common\FieldNameGenerator
-     */
-    private $fieldNameGenerator;
+    private FieldNameGenerator $fieldNameGenerator;
 
     public function __construct(
         FieldNameResolver $fieldNameResolver,

--- a/src/lib/Query/Common/CriterionVisitor/Field/FieldIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/Field/FieldIn.php
@@ -26,7 +26,7 @@ class FieldIn extends Field
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\Field &&
@@ -45,7 +45,7 @@ class FieldIn extends Field
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         $searchFields = $this->getSearchFields($criterion);
 

--- a/src/lib/Query/Common/CriterionVisitor/Field/FieldLike.php
+++ b/src/lib/Query/Common/CriterionVisitor/Field/FieldLike.php
@@ -26,7 +26,7 @@ class FieldLike extends Field
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return $criterion instanceof Criterion\Field && $criterion->operator === Operator::LIKE;
     }
@@ -41,7 +41,7 @@ class FieldLike extends Field
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         $searchFields = $this->getSearchFields($criterion);
 

--- a/src/lib/Query/Common/CriterionVisitor/Field/FieldRange.php
+++ b/src/lib/Query/Common/CriterionVisitor/Field/FieldRange.php
@@ -26,7 +26,7 @@ class FieldRange extends Field
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\Field &&
@@ -47,7 +47,7 @@ class FieldRange extends Field
      *
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentException If no searchable fields are found for the given criterion target.
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         $searchFields = $this->getSearchFields($criterion);
 

--- a/src/lib/Query/Common/CriterionVisitor/Field/FieldRelation.php
+++ b/src/lib/Query/Common/CriterionVisitor/Field/FieldRelation.php
@@ -26,7 +26,7 @@ class FieldRelation extends Field
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\FieldRelation &&
@@ -44,7 +44,7 @@ class FieldRelation extends Field
      *
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentException If no searchable fields are found for the given criterion target.
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         $searchFields = $this->getSearchFields($criterion, $criterion->target);
 

--- a/src/lib/Query/Common/CriterionVisitor/LanguageCodeIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/LanguageCodeIn.php
@@ -41,7 +41,7 @@ class LanguageCodeIn extends CriterionVisitor
     public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         $languageCodeExpressions = array_map(
-            static function (string $value): string {
+            static function (bool|float|int|string $value): string {
                 return 'content_language_codes_ms:"' . $value . '"';
             },
             $criterion->value

--- a/src/lib/Query/Common/CriterionVisitor/LanguageCodeIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/LanguageCodeIn.php
@@ -22,7 +22,7 @@ class LanguageCodeIn extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\LanguageCode &&
@@ -38,10 +38,10 @@ class LanguageCodeIn extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         $languageCodeExpressions = array_map(
-            static function ($value) {
+            static function (string $value): string {
                 return 'content_language_codes_ms:"' . $value . '"';
             },
             $criterion->value

--- a/src/lib/Query/Common/CriterionVisitor/LogicalAnd.php
+++ b/src/lib/Query/Common/CriterionVisitor/LogicalAnd.php
@@ -35,7 +35,7 @@ class LogicalAnd extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): false|string
     {
         /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\LogicalAnd $criterion */
         if (!isset($criterion->criteria[0])) {

--- a/src/lib/Query/Common/CriterionVisitor/LogicalNot.php
+++ b/src/lib/Query/Common/CriterionVisitor/LogicalNot.php
@@ -34,7 +34,7 @@ class LogicalNot extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         if (!isset($criterion->criteria[0]) ||
              (\count($criterion->criteria) > 1)) {

--- a/src/lib/Query/Common/CriterionVisitor/LogicalOr.php
+++ b/src/lib/Query/Common/CriterionVisitor/LogicalOr.php
@@ -35,7 +35,7 @@ class LogicalOr extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): false|string
     {
         /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\LogicalAnd $criterion */
         if (!isset($criterion->criteria[0])) {

--- a/src/lib/Query/Common/CriterionVisitor/MapLocation.php
+++ b/src/lib/Query/Common/CriterionVisitor/MapLocation.php
@@ -19,10 +19,8 @@ abstract class MapLocation extends CriterionVisitor
 {
     /**
      * Field map.
-     *
-     * @var \Ibexa\Core\Search\Common\FieldNameResolver
      */
-    protected $fieldNameResolver;
+    protected FieldNameResolver $fieldNameResolver;
 
     /**
      * Identifier of the field type that criterion can handle.

--- a/src/lib/Query/Common/CriterionVisitor/MapLocation/MapLocationDistanceIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/MapLocation/MapLocationDistanceIn.php
@@ -26,7 +26,7 @@ class MapLocationDistanceIn extends MapLocation
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\MapLocationDistance &&
@@ -44,7 +44,7 @@ class MapLocationDistanceIn extends MapLocation
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Value\MapLocationValue $location */
         $location = $criterion->valueData;

--- a/src/lib/Query/Common/CriterionVisitor/MapLocation/MapLocationDistanceRange.php
+++ b/src/lib/Query/Common/CriterionVisitor/MapLocation/MapLocationDistanceRange.php
@@ -26,7 +26,7 @@ class MapLocationDistanceRange extends MapLocation
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\MapLocationDistance &&
@@ -47,7 +47,7 @@ class MapLocationDistanceRange extends MapLocation
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         $criterion->value = (array)$criterion->value;
 

--- a/src/lib/Query/Common/CriterionVisitor/MatchAll.php
+++ b/src/lib/Query/Common/CriterionVisitor/MatchAll.php
@@ -34,7 +34,7 @@ class MatchAll extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         return '*:*';
     }

--- a/src/lib/Query/Common/CriterionVisitor/MatchNone.php
+++ b/src/lib/Query/Common/CriterionVisitor/MatchNone.php
@@ -34,7 +34,7 @@ class MatchNone extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         return '(NOT *:*)';
     }

--- a/src/lib/Query/Common/CriterionVisitor/ObjectStateIdIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/ObjectStateIdIn.php
@@ -22,7 +22,7 @@ class ObjectStateIdIn extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\ObjectStateId &&
@@ -40,13 +40,13 @@ class ObjectStateIdIn extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         return '(' .
             implode(
                 ' OR ',
                 array_map(
-                    static function ($value) {
+                    static function (string $value): string {
                         // TODO this should not be multiple???
                         return 'content_object_state_ids_mid:"' . $value . '"';
                     },

--- a/src/lib/Query/Common/CriterionVisitor/ObjectStateIdIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/ObjectStateIdIn.php
@@ -46,7 +46,7 @@ class ObjectStateIdIn extends CriterionVisitor
             implode(
                 ' OR ',
                 array_map(
-                    static function (string $value): string {
+                    static function (bool|float|int|string $value): string {
                         // TODO this should not be multiple???
                         return 'content_object_state_ids_mid:"' . $value . '"';
                     },

--- a/src/lib/Query/Common/CriterionVisitor/ObjectStateIdentifierIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/ObjectStateIdentifierIn.php
@@ -37,7 +37,7 @@ class ObjectStateIdentifierIn extends CriterionVisitor
             implode(
                 ' OR ',
                 array_map(
-                    function (string $value) use ($target) {
+                    function (string $value) use ($target): string {
                         return sprintf(
                             'content_object_state_identifiers_ms:%s',
                             $this->escapeExpressions("{$target}:{$value}", true)

--- a/src/lib/Query/Common/CriterionVisitor/RemoteIdIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/RemoteIdIn.php
@@ -22,7 +22,7 @@ class RemoteIdIn extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\RemoteId &&
@@ -40,13 +40,13 @@ class RemoteIdIn extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         return '(' .
             implode(
                 ' OR ',
                 array_map(
-                    static function ($value) {
+                    static function (string $value): string {
                         return 'content_remote_id_id:"' . $value . '"';
                     },
                     $criterion->value

--- a/src/lib/Query/Common/CriterionVisitor/RemoteIdIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/RemoteIdIn.php
@@ -46,7 +46,7 @@ class RemoteIdIn extends CriterionVisitor
             implode(
                 ' OR ',
                 array_map(
-                    static function (string $value): string {
+                    static function (bool|float|int|string $value): string {
                         return 'content_remote_id_id:"' . $value . '"';
                     },
                     $criterion->value

--- a/src/lib/Query/Common/CriterionVisitor/SectionIdentifierIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/SectionIdentifierIn.php
@@ -35,7 +35,7 @@ class SectionIdentifierIn extends CriterionVisitor
             implode(
                 ' OR ',
                 array_map(
-                    static function (string $value) {
+                    static function (string $value): string {
                         return 'content_section_identifier_id:"' . $value . '"';
                     },
                     (array) $criterion->value

--- a/src/lib/Query/Common/CriterionVisitor/SectionIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/SectionIn.php
@@ -46,7 +46,7 @@ class SectionIn extends CriterionVisitor
             implode(
                 ' OR ',
                 array_map(
-                    static function (string $value): string {
+                    static function (bool|float|int|string $value): string {
                         return 'content_section_id_id:"' . $value . '"';
                     },
                     $criterion->value

--- a/src/lib/Query/Common/CriterionVisitor/SectionIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/SectionIn.php
@@ -22,7 +22,7 @@ class SectionIn extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\SectionId &&
@@ -40,13 +40,13 @@ class SectionIn extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         return '(' .
             implode(
                 ' OR ',
                 array_map(
-                    static function ($value) {
+                    static function (string $value): string {
                         return 'content_section_id_id:"' . $value . '"';
                     },
                     $criterion->value

--- a/src/lib/Query/Common/CriterionVisitor/UserMetadataIn.php
+++ b/src/lib/Query/Common/CriterionVisitor/UserMetadataIn.php
@@ -23,7 +23,7 @@ class UserMetadataIn extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\UserMetadata &&
@@ -41,7 +41,7 @@ class UserMetadataIn extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         switch ($criterion->target) {
             case Criterion\UserMetadata::MODIFIER:
@@ -62,7 +62,7 @@ class UserMetadataIn extends CriterionVisitor
             implode(
                 ' OR ',
                 array_map(
-                    static function ($value) use ($solrField) {
+                    static function ($value) use ($solrField): string {
                         return "{$solrField}:\"{$value}\"";
                     },
                     $criterion->value

--- a/src/lib/Query/Common/QueryConverter/NativeQueryConverter.php
+++ b/src/lib/Query/Common/QueryConverter/NativeQueryConverter.php
@@ -20,22 +20,15 @@ class NativeQueryConverter extends QueryConverter
 {
     /**
      * Query visitor.
-     *
-     * @var \Ibexa\Contracts\Solr\Query\CriterionVisitor
      */
-    protected $criterionVisitor;
+    protected CriterionVisitor $criterionVisitor;
 
     /**
      * Sort clause visitor.
-     *
-     * @var \Ibexa\Contracts\Solr\Query\SortClauseVisitor
      */
-    protected $sortClauseVisitor;
+    protected SortClauseVisitor $sortClauseVisitor;
 
-    /**
-     * @var \Ibexa\Contracts\Solr\Query\AggregationVisitor
-     */
-    private $aggregationVisitor;
+    private AggregationVisitor $aggregationVisitor;
 
     /**
      * Construct from visitors.
@@ -53,7 +46,10 @@ class NativeQueryConverter extends QueryConverter
         $this->aggregationVisitor = $aggregationVisitor;
     }
 
-    public function convert(Query $query, array $languageSettings = [])
+    /**
+     * @return mixed[]
+     */
+    public function convert(Query $query, array $languageSettings = []): array
     {
         $params = [
             'q' => '{!lucene}' . ($query->query !== null ? $this->criterionVisitor->visit($query->query) : ''),
@@ -100,7 +96,7 @@ class NativeQueryConverter extends QueryConverter
      *
      * @return string
      */
-    private function getSortClauses(array $sortClauses)
+    private function getSortClauses(array $sortClauses): string
     {
         return implode(
             ', ',

--- a/src/lib/Query/Common/SortClauseVisitor/Aggregate.php
+++ b/src/lib/Query/Common/SortClauseVisitor/Aggregate.php
@@ -38,7 +38,7 @@ class Aggregate extends SortClauseVisitor
     /**
      * Adds visitor.
      */
-    public function addVisitor(SortClauseVisitor $visitor)
+    public function addVisitor(SortClauseVisitor $visitor): void
     {
         $this->visitors[] = $visitor;
     }
@@ -48,7 +48,7 @@ class Aggregate extends SortClauseVisitor
      *
      * @return bool
      */
-    public function canVisit(SortClause $sortClause)
+    public function canVisit(SortClause $sortClause): bool
     {
         return true;
     }

--- a/src/lib/Query/Common/SortClauseVisitor/ContentId.php
+++ b/src/lib/Query/Common/SortClauseVisitor/ContentId.php
@@ -30,7 +30,7 @@ class ContentId extends SortClauseVisitor
      *
      * @return string
      */
-    public function visit(SortClause $sortClause)
+    public function visit(SortClause $sortClause): string
     {
         return 'content_id_normalized_i' . $this->getDirection($sortClause);
     }

--- a/src/lib/Query/Common/SortClauseVisitor/ContentName.php
+++ b/src/lib/Query/Common/SortClauseVisitor/ContentName.php
@@ -30,7 +30,7 @@ class ContentName extends SortClauseVisitor
      *
      * @return string
      */
-    public function visit(SortClause $sortClause)
+    public function visit(SortClause $sortClause): string
     {
         return 'content_name_s' . $this->getDirection($sortClause);
     }

--- a/src/lib/Query/Common/SortClauseVisitor/DateModified.php
+++ b/src/lib/Query/Common/SortClauseVisitor/DateModified.php
@@ -30,7 +30,7 @@ class DateModified extends SortClauseVisitor
      *
      * @return string
      */
-    public function visit(SortClause $sortClause)
+    public function visit(SortClause $sortClause): string
     {
         return 'content_modification_date_dt' . $this->getDirection($sortClause);
     }

--- a/src/lib/Query/Common/SortClauseVisitor/DatePublished.php
+++ b/src/lib/Query/Common/SortClauseVisitor/DatePublished.php
@@ -30,7 +30,7 @@ class DatePublished extends SortClauseVisitor
      *
      * @return string
      */
-    public function visit(SortClause $sortClause)
+    public function visit(SortClause $sortClause): string
     {
         return 'content_publication_date_dt' . $this->getDirection($sortClause);
     }

--- a/src/lib/Query/Common/SortClauseVisitor/Field.php
+++ b/src/lib/Query/Common/SortClauseVisitor/Field.php
@@ -19,10 +19,8 @@ class Field extends SortClauseVisitor
 {
     /**
      * Field name resolver.
-     *
-     * @var \Ibexa\Core\Search\Common\FieldNameResolver
      */
-    protected $fieldNameResolver;
+    protected FieldNameResolver $fieldNameResolver;
 
     /**
      * Create from field name resolver.
@@ -77,7 +75,7 @@ class Field extends SortClauseVisitor
      *
      * @return string
      */
-    public function visit(SortClause $sortClause)
+    public function visit(SortClause $sortClause): string
     {
         /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\Target\FieldTarget $target */
         $target = $sortClause->targetData;

--- a/src/lib/Query/Common/SortClauseVisitor/MapLocationDistance.php
+++ b/src/lib/Query/Common/SortClauseVisitor/MapLocationDistance.php
@@ -26,10 +26,8 @@ class MapLocationDistance extends SortClauseVisitor
 
     /**
      * Field name resolver.
-     *
-     * @var \Ibexa\Core\Search\Common\FieldNameResolver
      */
-    protected $fieldNameResolver;
+    protected FieldNameResolver $fieldNameResolver;
 
     /**
      * Create from field name resolver and field name.
@@ -88,7 +86,7 @@ class MapLocationDistance extends SortClauseVisitor
      *
      * @return string
      */
-    public function visit(SortClause $sortClause)
+    public function visit(SortClause $sortClause): string
     {
         /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\Target\MapLocationTarget $target */
         $target = $sortClause->targetData;

--- a/src/lib/Query/Common/SortClauseVisitor/Random.php
+++ b/src/lib/Query/Common/SortClauseVisitor/Random.php
@@ -34,7 +34,7 @@ class Random extends SortClauseVisitor
      *
      * @return string
      */
-    public function visit(SortClause $sortClause)
+    public function visit(SortClause $sortClause): string
     {
         $seed = $sortClause->targetData->seed ?? mt_rand();
 

--- a/src/lib/Query/Common/SortClauseVisitor/SectionIdentifier.php
+++ b/src/lib/Query/Common/SortClauseVisitor/SectionIdentifier.php
@@ -30,7 +30,7 @@ class SectionIdentifier extends SortClauseVisitor
      *
      * @return string
      */
-    public function visit(SortClause $sortClause)
+    public function visit(SortClause $sortClause): string
     {
         return 'content_section_identifier_id' . $this->getDirection($sortClause);
     }

--- a/src/lib/Query/Common/SortClauseVisitor/SectionName.php
+++ b/src/lib/Query/Common/SortClauseVisitor/SectionName.php
@@ -30,7 +30,7 @@ class SectionName extends SortClauseVisitor
      *
      * @return string
      */
-    public function visit(SortClause $sortClause)
+    public function visit(SortClause $sortClause): string
     {
         return 'content_section_name_s' . $this->getDirection($sortClause);
     }

--- a/src/lib/Query/Content/CriterionVisitor/Ancestor.php
+++ b/src/lib/Query/Content/CriterionVisitor/Ancestor.php
@@ -35,7 +35,7 @@ class Ancestor extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         $idSet = [];
         foreach ($criterion->value as $value) {
@@ -48,7 +48,7 @@ class Ancestor extends CriterionVisitor
             implode(
                 ' OR ',
                 array_map(
-                    static function ($value) {
+                    static function (string $value): string {
                         return 'location_id_mid:"' . $value . '"';
                     },
                     array_keys($idSet)

--- a/src/lib/Query/Content/CriterionVisitor/Factory/FullTextFactory.php
+++ b/src/lib/Query/Content/CriterionVisitor/Factory/FullTextFactory.php
@@ -26,30 +26,16 @@ final class FullTextFactory
 {
     /**
      * Field map.
-     *
-     * @var \Ibexa\Core\Search\Common\FieldNameResolver
      */
-    private $fieldNameResolver;
+    private FieldNameResolver $fieldNameResolver;
 
-    /**
-     * @var \QueryTranslator\Languages\Galach\Tokenizer
-     */
-    private $tokenizer;
+    private Tokenizer $tokenizer;
 
-    /**
-     * @var \QueryTranslator\Languages\Galach\Parser
-     */
-    private $parser;
+    private Parser $parser;
 
-    /**
-     * @var \QueryTranslator\Languages\Galach\Generators\ExtendedDisMax
-     */
-    private $generator;
+    private ExtendedDisMax $generator;
 
-    /**
-     * @var \Ibexa\Solr\FieldMapper\IndexingDepthProvider
-     */
-    private $indexingDepthProvider;
+    private IndexingDepthProvider $indexingDepthProvider;
 
     /**
      * Create from content type handler and field registry.

--- a/src/lib/Query/Content/CriterionVisitor/FullText.php
+++ b/src/lib/Query/Content/CriterionVisitor/FullText.php
@@ -23,25 +23,14 @@ class FullText extends CriterionVisitor
 {
     /**
      * Field map.
-     *
-     * @var \Ibexa\Core\Search\Common\FieldNameResolver
      */
-    protected $fieldNameResolver;
+    protected FieldNameResolver $fieldNameResolver;
 
-    /**
-     * @var \QueryTranslator\Languages\Galach\Tokenizer
-     */
-    protected $tokenizer;
+    protected Tokenizer $tokenizer;
 
-    /**
-     * @var \QueryTranslator\Languages\Galach\Parser
-     */
-    protected $parser;
+    protected Parser $parser;
 
-    /**
-     * @var \QueryTranslator\Languages\Galach\Generators\ExtendedDisMax
-     */
-    protected $generator;
+    protected ExtendedDisMax $generator;
 
     /**
      * @var int
@@ -97,7 +86,7 @@ class FullText extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\FullText $criterion */
         $tokenSequence = $this->tokenizer->tokenize($criterion->value);
@@ -115,7 +104,7 @@ class FullText extends CriterionVisitor
         return "{!edismax v='{$queryStringEscaped}' qf='{$queryFields}' uf=-*}";
     }
 
-    private function getQueryFields(Criterion $criterion)
+    private function getQueryFields(Criterion $criterion): string
     {
         /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\FullText $criterion */
         $queryFields = ['meta_content__text_t'];

--- a/src/lib/Query/Content/CriterionVisitor/LocationIdIn.php
+++ b/src/lib/Query/Content/CriterionVisitor/LocationIdIn.php
@@ -22,7 +22,7 @@ class LocationIdIn extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\LocationId &&
@@ -38,13 +38,13 @@ class LocationIdIn extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         return '(' .
             implode(
                 ' OR ',
                 array_map(
-                    static function ($id) {
+                    static function (string $id): string {
                         return 'location_id_mid:"' . $id . '"';
                     },
                     $criterion->value

--- a/src/lib/Query/Content/CriterionVisitor/LocationIdIn.php
+++ b/src/lib/Query/Content/CriterionVisitor/LocationIdIn.php
@@ -44,7 +44,7 @@ class LocationIdIn extends CriterionVisitor
             implode(
                 ' OR ',
                 array_map(
-                    static function (string $id): string {
+                    static function (bool|float|int|string $id): string {
                         return 'location_id_mid:"' . $id . '"';
                     },
                     $criterion->value

--- a/src/lib/Query/Content/CriterionVisitor/LocationRemoteIdIn.php
+++ b/src/lib/Query/Content/CriterionVisitor/LocationRemoteIdIn.php
@@ -44,7 +44,7 @@ class LocationRemoteIdIn extends CriterionVisitor
             implode(
                 ' OR ',
                 array_map(
-                    static function (string $id): string {
+                    static function (bool|float|int|string $id): string {
                         return 'location_remote_id_mid:"' . $id . '"';
                     },
                     $criterion->value

--- a/src/lib/Query/Content/CriterionVisitor/LocationRemoteIdIn.php
+++ b/src/lib/Query/Content/CriterionVisitor/LocationRemoteIdIn.php
@@ -22,7 +22,7 @@ class LocationRemoteIdIn extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\LocationRemoteId &&
@@ -38,13 +38,13 @@ class LocationRemoteIdIn extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         return '(' .
             implode(
                 ' OR ',
                 array_map(
-                    static function ($id) {
+                    static function (string $id): string {
                         return 'location_remote_id_mid:"' . $id . '"';
                     },
                     $criterion->value

--- a/src/lib/Query/Content/CriterionVisitor/ParentLocationIdIn.php
+++ b/src/lib/Query/Content/CriterionVisitor/ParentLocationIdIn.php
@@ -22,7 +22,7 @@ class ParentLocationIdIn extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\ParentLocationId &&
@@ -38,13 +38,13 @@ class ParentLocationIdIn extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         return '(' .
             implode(
                 ' OR ',
                 array_map(
-                    static function ($id) {
+                    static function (string $id): string {
                         return 'location_parent_id_mid:"' . $id . '"';
                     },
                     $criterion->value

--- a/src/lib/Query/Content/CriterionVisitor/ParentLocationIdIn.php
+++ b/src/lib/Query/Content/CriterionVisitor/ParentLocationIdIn.php
@@ -44,7 +44,7 @@ class ParentLocationIdIn extends CriterionVisitor
             implode(
                 ' OR ',
                 array_map(
-                    static function (string $id): string {
+                    static function (bool|float|int|string $id): string {
                         return 'location_parent_id_mid:"' . $id . '"';
                     },
                     $criterion->value

--- a/src/lib/Query/Content/CriterionVisitor/SubtreeIn.php
+++ b/src/lib/Query/Content/CriterionVisitor/SubtreeIn.php
@@ -22,7 +22,7 @@ class SubtreeIn extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\Subtree &&
@@ -38,13 +38,13 @@ class SubtreeIn extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         return '(' .
             implode(
                 ' OR ',
                 array_map(
-                    static function ($value) {
+                    static function ($value): string {
                         return 'location_path_string_mid:' . str_replace('/', '\\/', $value) . '*';
                     },
                     $criterion->value

--- a/src/lib/Query/Content/CriterionVisitor/Visibility.php
+++ b/src/lib/Query/Content/CriterionVisitor/Visibility.php
@@ -22,7 +22,7 @@ class Visibility extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return $criterion instanceof Criterion\Visibility && $criterion->operator === Operator::EQ;
     }
@@ -36,7 +36,7 @@ class Visibility extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         return 'location_visible_b:' . ($criterion->value[0] === Criterion\Visibility::VISIBLE ? 'true' : 'false');
     }

--- a/src/lib/Query/Location/CriterionVisitor/Ancestor.php
+++ b/src/lib/Query/Location/CriterionVisitor/Ancestor.php
@@ -35,7 +35,7 @@ class Ancestor extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         $idSet = [];
         foreach ($criterion->value as $value) {
@@ -48,7 +48,7 @@ class Ancestor extends CriterionVisitor
             implode(
                 ' OR ',
                 array_map(
-                    static function ($value) {
+                    static function (string $value): string {
                         return 'location_id:"' . $value . '"';
                     },
                     array_keys($idSet)

--- a/src/lib/Query/Location/CriterionVisitor/FullText.php
+++ b/src/lib/Query/Location/CriterionVisitor/FullText.php
@@ -24,7 +24,7 @@ class FullText extends ContentFullText
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         $condition = $this->escapeQuote(parent::visit($criterion, $subVisitor));
 

--- a/src/lib/Query/Location/CriterionVisitor/Location/DepthBetween.php
+++ b/src/lib/Query/Location/CriterionVisitor/Location/DepthBetween.php
@@ -22,7 +22,7 @@ class DepthBetween extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\Location\Depth &&
@@ -43,7 +43,7 @@ class DepthBetween extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         $start = $criterion->value[0];
         $end = isset($criterion->value[1]) ? $criterion->value[1] : null;

--- a/src/lib/Query/Location/CriterionVisitor/Location/DepthIn.php
+++ b/src/lib/Query/Location/CriterionVisitor/Location/DepthIn.php
@@ -22,7 +22,7 @@ class DepthIn extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\Location\Depth &&
@@ -40,7 +40,7 @@ class DepthIn extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         $values = [];
         foreach ($criterion->value as $value) {

--- a/src/lib/Query/Location/CriterionVisitor/Location/IsMainLocation.php
+++ b/src/lib/Query/Location/CriterionVisitor/Location/IsMainLocation.php
@@ -34,7 +34,7 @@ class IsMainLocation extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         return 'is_main_location_b:' . ($criterion->value[0] === Criterion\Location\IsMainLocation::MAIN ? 'true' : 'false');
     }

--- a/src/lib/Query/Location/CriterionVisitor/Location/PriorityBetween.php
+++ b/src/lib/Query/Location/CriterionVisitor/Location/PriorityBetween.php
@@ -22,7 +22,7 @@ class PriorityBetween extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\Location\Priority &&
@@ -43,7 +43,7 @@ class PriorityBetween extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         $start = $criterion->value[0];
         $end = isset($criterion->value[1]) ? $criterion->value[1] : null;

--- a/src/lib/Query/Location/CriterionVisitor/Location/PriorityIn.php
+++ b/src/lib/Query/Location/CriterionVisitor/Location/PriorityIn.php
@@ -22,7 +22,7 @@ class PriorityIn extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\Location\Priority &&
@@ -40,7 +40,7 @@ class PriorityIn extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         $values = [];
         foreach ($criterion->value as $value) {

--- a/src/lib/Query/Location/CriterionVisitor/LocationIdIn.php
+++ b/src/lib/Query/Location/CriterionVisitor/LocationIdIn.php
@@ -44,7 +44,7 @@ class LocationIdIn extends CriterionVisitor
             implode(
                 ' OR ',
                 array_map(
-                    static function (string $value): string {
+                    static function (bool|float|int|string $value): string {
                         return 'location_id:"' . $value . '"';
                     },
                     $criterion->value

--- a/src/lib/Query/Location/CriterionVisitor/LocationIdIn.php
+++ b/src/lib/Query/Location/CriterionVisitor/LocationIdIn.php
@@ -22,7 +22,7 @@ class LocationIdIn extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\LocationId &&
@@ -38,13 +38,13 @@ class LocationIdIn extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         return '(' .
             implode(
                 ' OR ',
                 array_map(
-                    static function ($value) {
+                    static function (string $value): string {
                         return 'location_id:"' . $value . '"';
                     },
                     $criterion->value

--- a/src/lib/Query/Location/CriterionVisitor/LocationRemoteIdIn.php
+++ b/src/lib/Query/Location/CriterionVisitor/LocationRemoteIdIn.php
@@ -22,7 +22,7 @@ class LocationRemoteIdIn extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\LocationRemoteId &&
@@ -40,13 +40,13 @@ class LocationRemoteIdIn extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         return '(' .
             implode(
                 ' OR ',
                 array_map(
-                    static function ($value) {
+                    static function (string $value): string {
                         return 'remote_id_id:"' . $value . '"';
                     },
                     $criterion->value

--- a/src/lib/Query/Location/CriterionVisitor/LocationRemoteIdIn.php
+++ b/src/lib/Query/Location/CriterionVisitor/LocationRemoteIdIn.php
@@ -46,7 +46,7 @@ class LocationRemoteIdIn extends CriterionVisitor
             implode(
                 ' OR ',
                 array_map(
-                    static function (string $value): string {
+                    static function (bool|float|int|string $value): string {
                         return 'remote_id_id:"' . $value . '"';
                     },
                     $criterion->value

--- a/src/lib/Query/Location/CriterionVisitor/ParentLocationIdIn.php
+++ b/src/lib/Query/Location/CriterionVisitor/ParentLocationIdIn.php
@@ -22,7 +22,7 @@ class ParentLocationIdIn extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\ParentLocationId &&
@@ -40,13 +40,13 @@ class ParentLocationIdIn extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         return '(' .
             implode(
                 ' OR ',
                 array_map(
-                    static function ($value) {
+                    static function (string $value): string {
                         return 'parent_id_id:"' . $value . '"';
                     },
                     $criterion->value

--- a/src/lib/Query/Location/CriterionVisitor/ParentLocationIdIn.php
+++ b/src/lib/Query/Location/CriterionVisitor/ParentLocationIdIn.php
@@ -46,7 +46,7 @@ class ParentLocationIdIn extends CriterionVisitor
             implode(
                 ' OR ',
                 array_map(
-                    static function (string $value): string {
+                    static function (bool|float|int|string $value): string {
                         return 'parent_id_id:"' . $value . '"';
                     },
                     $criterion->value

--- a/src/lib/Query/Location/CriterionVisitor/SubtreeIn.php
+++ b/src/lib/Query/Location/CriterionVisitor/SubtreeIn.php
@@ -22,7 +22,7 @@ class SubtreeIn extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return
             $criterion instanceof Criterion\Subtree &&
@@ -40,13 +40,13 @@ class SubtreeIn extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         return '(' .
             implode(
                 ' OR ',
                 array_map(
-                    static function ($value) {
+                    static function ($value): string {
                         return 'path_string_id:' . str_replace('/', '\\/', $value) . '*';
                     },
                     $criterion->value

--- a/src/lib/Query/Location/CriterionVisitor/Visibility.php
+++ b/src/lib/Query/Location/CriterionVisitor/Visibility.php
@@ -22,7 +22,7 @@ class Visibility extends CriterionVisitor
      *
      * @return bool
      */
-    public function canVisit(CriterionInterface $criterion)
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return $criterion instanceof Criterion\Visibility && $criterion->operator === Operator::EQ;
     }
@@ -35,7 +35,7 @@ class Visibility extends CriterionVisitor
      *
      * @return string
      */
-    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(CriterionInterface $criterion, CriterionVisitor $subVisitor = null): string
     {
         return 'invisible_b:' . ($criterion->value[0] === Criterion\Visibility::HIDDEN ? 'true' : 'false');
     }

--- a/src/lib/Query/Location/SortClauseVisitor/Location/Depth.php
+++ b/src/lib/Query/Location/SortClauseVisitor/Location/Depth.php
@@ -30,7 +30,7 @@ class Depth extends SortClauseVisitor
      *
      * @return string
      */
-    public function visit(SortClause $sortClause)
+    public function visit(SortClause $sortClause): string
     {
         return 'depth_i' . $this->getDirection($sortClause);
     }

--- a/src/lib/Query/Location/SortClauseVisitor/Location/Id.php
+++ b/src/lib/Query/Location/SortClauseVisitor/Location/Id.php
@@ -30,7 +30,7 @@ class Id extends SortClauseVisitor
      *
      * @return string
      */
-    public function visit(SortClause $sortClause)
+    public function visit(SortClause $sortClause): string
     {
         return 'location_id_normalized_i' . $this->getDirection($sortClause);
     }

--- a/src/lib/Query/Location/SortClauseVisitor/Location/IsMainLocation.php
+++ b/src/lib/Query/Location/SortClauseVisitor/Location/IsMainLocation.php
@@ -30,7 +30,7 @@ class IsMainLocation extends SortClauseVisitor
      *
      * @return string
      */
-    public function visit(SortClause $sortClause)
+    public function visit(SortClause $sortClause): string
     {
         return 'is_main_location_b' . $this->getDirection($sortClause);
     }

--- a/src/lib/Query/Location/SortClauseVisitor/Location/Path.php
+++ b/src/lib/Query/Location/SortClauseVisitor/Location/Path.php
@@ -30,7 +30,7 @@ class Path extends SortClauseVisitor
      *
      * @return string
      */
-    public function visit(SortClause $sortClause)
+    public function visit(SortClause $sortClause): string
     {
         return 'path_string_id' . $this->getDirection($sortClause);
     }

--- a/src/lib/Query/Location/SortClauseVisitor/Location/Priority.php
+++ b/src/lib/Query/Location/SortClauseVisitor/Location/Priority.php
@@ -30,7 +30,7 @@ class Priority extends SortClauseVisitor
      *
      * @return string
      */
-    public function visit(SortClause $sortClause)
+    public function visit(SortClause $sortClause): string
     {
         return 'priority_i' . $this->getDirection($sortClause);
     }

--- a/src/lib/Query/Location/SortClauseVisitor/Location/Visibility.php
+++ b/src/lib/Query/Location/SortClauseVisitor/Location/Visibility.php
@@ -30,7 +30,7 @@ class Visibility extends SortClauseVisitor
      *
      * @return string
      */
-    public function visit(SortClause $sortClause)
+    public function visit(SortClause $sortClause): string
     {
         return 'invisible_b' . $this->getDirection($sortClause);
     }

--- a/src/lib/ResultExtractor.php
+++ b/src/lib/ResultExtractor.php
@@ -22,11 +22,9 @@ use stdClass;
  */
 abstract class ResultExtractor
 {
-    /** @var \Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor */
-    protected $aggregationResultExtractor;
+    protected AggregationResultExtractor $aggregationResultExtractor;
 
-    /** @var \Ibexa\Solr\Gateway\EndpointRegistry */
-    protected $endpointRegistry;
+    protected EndpointRegistry $endpointRegistry;
 
     public function __construct(
         AggregationResultExtractor $aggregationResultExtractor,
@@ -46,7 +44,7 @@ abstract class ResultExtractor
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Search\SearchResult<\Ibexa\Contracts\Core\Repository\Values\ValueObject>
      */
     public function extract(
-        $data,
+        stdClass $data,
         array $aggregations = [],
         array $languageFilter = [],
         ?Spellcheck $spellcheck = null

--- a/src/lib/ResultExtractor.php
+++ b/src/lib/ResultExtractor.php
@@ -37,7 +37,7 @@ abstract class ResultExtractor
     /**
      * Extracts search result from $data returned by Solr backend.
      *
-     * @param mixed $data
+     * @param \stdClass $data
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation[] $aggregations
      * @param array $languageFilter
      *

--- a/src/lib/ResultExtractor/AggregationResultExtractor/DispatcherAggregationResultExtractor.php
+++ b/src/lib/ResultExtractor/AggregationResultExtractor/DispatcherAggregationResultExtractor.php
@@ -17,7 +17,7 @@ use stdClass;
 final class DispatcherAggregationResultExtractor implements AggregationResultExtractor
 {
     /** @var \Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor[] */
-    private $extractors;
+    private iterable $extractors;
 
     /**
      * @param \Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor[] $extractors

--- a/src/lib/ResultExtractor/AggregationResultExtractor/NestedAggregationResultExtractor.php
+++ b/src/lib/ResultExtractor/AggregationResultExtractor/NestedAggregationResultExtractor.php
@@ -15,11 +15,9 @@ use stdClass;
 
 final class NestedAggregationResultExtractor implements AggregationResultExtractor
 {
-    /** @var \Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor */
-    private $innerResultExtractor;
+    private AggregationResultExtractor $innerResultExtractor;
 
-    /** @var string */
-    private $nestedResultKey;
+    private string $nestedResultKey;
 
     public function __construct(AggregationResultExtractor $innerResultExtractor, string $nestedResultKey)
     {

--- a/src/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/DateTimeRangeAggregationKeyMapper.php
+++ b/src/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/DateTimeRangeAggregationKeyMapper.php
@@ -14,7 +14,7 @@ use Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\RangeAggrega
 
 final class DateTimeRangeAggregationKeyMapper implements RangeAggregationKeyMapper
 {
-    public function map(Aggregation $aggregation, array $languageFilter, string $key)
+    public function map(Aggregation $aggregation, array $languageFilter, string $key): ?DateTimeImmutable
     {
         if ($key === '*') {
             return null;

--- a/src/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/FloatRangeAggregationKeyMapper.php
+++ b/src/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/FloatRangeAggregationKeyMapper.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\RangeAggrega
 
 final class FloatRangeAggregationKeyMapper implements RangeAggregationKeyMapper
 {
-    public function map(Aggregation $aggregation, array $languageFilter, string $key)
+    public function map(Aggregation $aggregation, array $languageFilter, string $key): ?float
     {
         if ($key === '*') {
             return null;

--- a/src/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/IntRangeAggregationKeyMapper.php
+++ b/src/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/IntRangeAggregationKeyMapper.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\RangeAggrega
 
 final class IntRangeAggregationKeyMapper implements RangeAggregationKeyMapper
 {
-    public function map(Aggregation $aggregation, array $languageFilter, string $key)
+    public function map(Aggregation $aggregation, array $languageFilter, string $key): ?int
     {
         if ($key === '*') {
             return null;

--- a/src/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/NullRangeAggregationKeyMapper.php
+++ b/src/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/NullRangeAggregationKeyMapper.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\RangeAggrega
 
 final class NullRangeAggregationKeyMapper implements RangeAggregationKeyMapper
 {
-    public function map(Aggregation $aggregation, array $languageFilter, string $key)
+    public function map(Aggregation $aggregation, array $languageFilter, string $key): ?string
     {
         if ($key === '*') {
             return null;

--- a/src/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationResultExtractor.php
+++ b/src/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationResultExtractor.php
@@ -19,11 +19,9 @@ use stdClass;
 
 final class RangeAggregationResultExtractor implements AggregationResultExtractor
 {
-    /** @var string */
-    private $aggregationClass;
+    private string $aggregationClass;
 
-    /** @var \Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper */
-    private $keyMapper;
+    private RangeAggregationKeyMapper $keyMapper;
 
     public function __construct(string $aggregationClass, RangeAggregationKeyMapper $keyMapper)
     {

--- a/src/lib/ResultExtractor/AggregationResultExtractor/StatsAggregationResultExtractor.php
+++ b/src/lib/ResultExtractor/AggregationResultExtractor/StatsAggregationResultExtractor.php
@@ -16,8 +16,7 @@ use stdClass;
 
 final class StatsAggregationResultExtractor implements AggregationResultExtractor
 {
-    /** @var string */
-    private $aggregationClass;
+    private string $aggregationClass;
 
     public function __construct(string $aggregationClass)
     {

--- a/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeAggregationKeyMapper.php
+++ b/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeAggregationKeyMapper.php
@@ -14,8 +14,7 @@ use Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\TermAggregat
 
 final class ContentTypeAggregationKeyMapper implements TermAggregationKeyMapper
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
     public function __construct(ContentTypeService $contentTypeService)
     {

--- a/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeGroupAggregationKeyMapper.php
+++ b/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeGroupAggregationKeyMapper.php
@@ -15,8 +15,7 @@ use Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\TermAggregat
 
 final class ContentTypeGroupAggregationKeyMapper implements TermAggregationKeyMapper
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
     public function __construct(ContentTypeService $contentTypeService)
     {

--- a/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/CountryAggregationKeyMapper.php
+++ b/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/CountryAggregationKeyMapper.php
@@ -14,8 +14,7 @@ use Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\TermAggregat
 
 final class CountryAggregationKeyMapper implements TermAggregationKeyMapper
 {
-    /** @var array */
-    private $countriesInfo;
+    private array $countriesInfo;
 
     /**
      * @param array $countriesInfo Array of countries data

--- a/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LanguageAggregationKeyMapper.php
+++ b/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LanguageAggregationKeyMapper.php
@@ -14,8 +14,7 @@ use Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\TermAggregat
 
 final class LanguageAggregationKeyMapper implements TermAggregationKeyMapper
 {
-    /** @var \Ibexa\Contracts\Core\Repository\LanguageService */
-    private $languageService;
+    private LanguageService $languageService;
 
     public function __construct(LanguageService $languageService)
     {

--- a/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LocationAggregationKeyMapper.php
+++ b/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LocationAggregationKeyMapper.php
@@ -14,8 +14,7 @@ use Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\TermAggregat
 
 final class LocationAggregationKeyMapper implements TermAggregationKeyMapper
 {
-    /** @var \Ibexa\Contracts\Core\Repository\LocationService */
-    private $locationService;
+    private LocationService $locationService;
 
     public function __construct(LocationService $locationService)
     {

--- a/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ObjectStateAggregationKeyMapper.php
+++ b/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ObjectStateAggregationKeyMapper.php
@@ -15,8 +15,7 @@ use Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\TermAggregat
 
 final class ObjectStateAggregationKeyMapper implements TermAggregationKeyMapper
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ObjectStateService */
-    private $objectStateService;
+    private ObjectStateService $objectStateService;
 
     public function __construct(ObjectStateService $objectStateService)
     {

--- a/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SectionAggregationKeyMapper.php
+++ b/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SectionAggregationKeyMapper.php
@@ -16,8 +16,7 @@ use Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\TermAggregat
 
 final class SectionAggregationKeyMapper implements TermAggregationKeyMapper
 {
-    /** @var \Ibexa\Contracts\Core\Repository\SectionService */
-    private $sectionService;
+    private SectionService $sectionService;
 
     public function __construct(SectionService $sectionService)
     {

--- a/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SubtreeAggregationKeyMapper.php
+++ b/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SubtreeAggregationKeyMapper.php
@@ -13,8 +13,7 @@ use Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\TermAggregat
 
 final class SubtreeAggregationKeyMapper implements TermAggregationKeyMapper
 {
-    /** @var \Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper */
-    private $locationAggregationKeyMapper;
+    private TermAggregationKeyMapper $locationAggregationKeyMapper;
 
     public function __construct(TermAggregationKeyMapper $locationAggregationKeyMapper)
     {

--- a/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/UserMetadataAggregationKeyMapper.php
+++ b/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/UserMetadataAggregationKeyMapper.php
@@ -18,8 +18,7 @@ use InvalidArgumentException;
 
 final class UserMetadataAggregationKeyMapper implements TermAggregationKeyMapper
 {
-    /** @var \Ibexa\Contracts\Core\Repository\UserService */
-    private $userService;
+    private UserService $userService;
 
     public function __construct(UserService $userService)
     {

--- a/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationResultExtractor.php
+++ b/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationResultExtractor.php
@@ -19,11 +19,9 @@ use stdClass;
 
 final class TermAggregationResultExtractor implements AggregationResultExtractor
 {
-    /** @var \Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper */
-    private $keyMapper;
+    private ?TermAggregationKeyMapper $keyMapper;
 
-    /** @var string */
-    private $aggregationClass;
+    private string $aggregationClass;
 
     public function __construct(string $aggregationClass, TermAggregationKeyMapper $keyMapper = null)
     {

--- a/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationResultExtractor.php
+++ b/src/lib/ResultExtractor/AggregationResultExtractor/TermAggregationResultExtractor.php
@@ -19,7 +19,7 @@ use stdClass;
 
 final class TermAggregationResultExtractor implements AggregationResultExtractor
 {
-    private ?TermAggregationKeyMapper $keyMapper;
+    private TermAggregationKeyMapper $keyMapper;
 
     private string $aggregationClass;
 

--- a/src/lib/ResultExtractor/LoadingResultExtractor.php
+++ b/src/lib/ResultExtractor/LoadingResultExtractor.php
@@ -7,6 +7,7 @@
 
 namespace Ibexa\Solr\ResultExtractor;
 
+use Ibexa\Contracts\Core\Persistence\Content\Handler;
 use Ibexa\Contracts\Core\Persistence\Content\Handler as ContentHandler;
 use Ibexa\Contracts\Core\Persistence\Content\Location\Handler as LocationHandler;
 use Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor;
@@ -22,17 +23,13 @@ class LoadingResultExtractor extends ResultExtractor
 {
     /**
      * Content handler.
-     *
-     * @var \Ibexa\Contracts\Core\Persistence\Content\Handler
      */
-    protected $contentHandler;
+    protected Handler $contentHandler;
 
     /**
      * Location handler.
-     *
-     * @var \Ibexa\Contracts\Core\Persistence\Content\Location\Handler
      */
-    protected $locationHandler;
+    protected LocationHandler $locationHandler;
 
     public function __construct(
         ContentHandler $contentHandler,

--- a/src/lib/ResultExtractor/NativeResultExtractor.php
+++ b/src/lib/ResultExtractor/NativeResultExtractor.php
@@ -45,7 +45,7 @@ class NativeResultExtractor extends ResultExtractor
      *
      * @return \Ibexa\Contracts\Core\Persistence\Content\ContentInfo
      */
-    protected function extractContentInfoFromHit($hit)
+    protected function extractContentInfoFromHit($hit): ContentInfo
     {
         $contentInfo = new ContentInfo(
             [
@@ -76,7 +76,7 @@ class NativeResultExtractor extends ResultExtractor
      *
      * @return \Ibexa\Contracts\Core\Persistence\Content\Location
      */
-    protected function extractLocationFromHit($hit)
+    protected function extractLocationFromHit($hit): Location
     {
         return new Location(
             [

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,7 +4,6 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-
 use Ibexa\Core\Persistence\Legacy\Content\Gateway\DoctrineDatabase;
 use Ibexa\Core\Persistence\Legacy\Content\Gateway\DoctrineDatabase\QueryBuilder;
 use Ibexa\Core\Repository\ContentService;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,9 +4,22 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
+use Ibexa\Core\Persistence\Legacy\Content\Gateway\DoctrineDatabase;
+use Ibexa\Core\Persistence\Legacy\Content\Gateway\DoctrineDatabase\QueryBuilder;
+use Ibexa\Core\Repository\ContentService;
+use Symfony\Bridge\PhpUnit\ClockMock;
+
 $file = __DIR__ . '/../vendor/autoload.php';
 if (!file_exists($file)) {
     throw new RuntimeException('Install dependencies using composer to run the test suite.');
 }
+
+// Register ClockMock, as otherwise they are mocked until first method call.
+// Those Mocks are needed for core integration setup.
+
+ClockMock::register(DoctrineDatabase::class);
+ClockMock::register(ContentService::class);
+ClockMock::register(QueryBuilder::class);
 
 $autoload = require_once $file;

--- a/tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
+++ b/tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
@@ -20,7 +20,7 @@ class IbexaSolrExtensionExtensionTest extends AbstractExtensionTestCase
     /**
      * @var \Ibexa\Bundle\Solr\DependencyInjection\IbexaSolrExtension
      */
-    private $extension;
+    private IbexaSolrExtension $extension;
 
     protected function setUp(): void
     {
@@ -39,13 +39,13 @@ class IbexaSolrExtensionExtensionTest extends AbstractExtensionTestCase
         return [];
     }
 
-    public function testEmpty()
+    public function testEmpty(): void
     {
         $this->load();
         $this->expectNotToPerformAssertions();
     }
 
-    public function dataProviderForTestEndpoint()
+    public function dataProviderForTestEndpoint(): array
     {
         return [
             [
@@ -136,7 +136,7 @@ class IbexaSolrExtensionExtensionTest extends AbstractExtensionTestCase
      * @param array $endpointValues
      * @param array $expectedArgument
      */
-    public function testEndpoint($endpointName, $endpointValues, $expectedArgument)
+    public function testEndpoint(string $endpointName, array $endpointValues, array $expectedArgument): void
     {
         $this->load(['endpoints' => [$endpointName => $endpointValues]]);
 
@@ -152,7 +152,7 @@ class IbexaSolrExtensionExtensionTest extends AbstractExtensionTestCase
         );
     }
 
-    public function testEndpointCoreRequired()
+    public function testEndpointCoreRequired(): void
     {
         $this->expectException(InvalidConfigurationException::class);
 
@@ -167,7 +167,7 @@ class IbexaSolrExtensionExtensionTest extends AbstractExtensionTestCase
         );
     }
 
-    public function dataProviderForTestConnection()
+    public function dataProviderForTestConnection(): array
     {
         return [
             [
@@ -223,7 +223,7 @@ class IbexaSolrExtensionExtensionTest extends AbstractExtensionTestCase
         }
     }
 
-    public function testConnection()
+    public function testConnection(): void
     {
         $configurationValues = [
             'connections' => [
@@ -287,7 +287,7 @@ class IbexaSolrExtensionExtensionTest extends AbstractExtensionTestCase
         );
     }
 
-    public function testConnectionEndpointDefaults()
+    public function testConnectionEndpointDefaults(): void
     {
         $configurationValues = [
             'connections' => [
@@ -347,7 +347,7 @@ class IbexaSolrExtensionExtensionTest extends AbstractExtensionTestCase
         );
     }
 
-    public function testConnectionEndpointUniqueDefaults()
+    public function testConnectionEndpointUniqueDefaults(): void
     {
         $configurationValues = [
             'connections' => [
@@ -405,7 +405,7 @@ class IbexaSolrExtensionExtensionTest extends AbstractExtensionTestCase
         );
     }
 
-    public function testConnectionMappingDefaults()
+    public function testConnectionMappingDefaults(): void
     {
         $configurationValues = [
             'connections' => [
@@ -452,7 +452,7 @@ class IbexaSolrExtensionExtensionTest extends AbstractExtensionTestCase
         );
     }
 
-    public function dataProvideForTestBoostFactorMap()
+    public function dataProvideForTestBoostFactorMap(): array
     {
         return [
             [
@@ -642,7 +642,7 @@ class IbexaSolrExtensionExtensionTest extends AbstractExtensionTestCase
     /**
      * @dataProvider dataProvideForTestBoostFactorMap
      */
-    public function testBoostFactorMap(array $configuration, array $map)
+    public function testBoostFactorMap(array $configuration, array $map): void
     {
         $this->load($configuration);
 

--- a/tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
+++ b/tests/bundle/DependencyInjection/IbexaSolrExtensionExtensionTest.php
@@ -29,11 +29,17 @@ class IbexaSolrExtensionExtensionTest extends AbstractExtensionTestCase
         parent::setUp();
     }
 
+    /**
+     * @return \Symfony\Component\DependencyInjection\Extension\ExtensionInterface[]
+     */
     protected function getContainerExtensions(): array
     {
         return [$this->extension];
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     protected function getMinimalConfiguration(): array
     {
         return [];
@@ -45,6 +51,9 @@ class IbexaSolrExtensionExtensionTest extends AbstractExtensionTestCase
         $this->expectNotToPerformAssertions();
     }
 
+    /**
+     * @phpstan-return list<array{string, array<string, mixed>, array<string, mixed>}>
+     */
     public function dataProviderForTestEndpoint(): array
     {
         return [
@@ -133,8 +142,8 @@ class IbexaSolrExtensionExtensionTest extends AbstractExtensionTestCase
      * @dataProvider dataProviderForTestEndpoint
      *
      * @param string $endpointName
-     * @param array $endpointValues
-     * @param array $expectedArgument
+     * @param array<string, mixed> $endpointValues
+     * @param array<string, mixed> $expectedArgument
      */
     public function testEndpoint(string $endpointName, array $endpointValues, array $expectedArgument): void
     {
@@ -167,6 +176,9 @@ class IbexaSolrExtensionExtensionTest extends AbstractExtensionTestCase
         );
     }
 
+    /**
+     * @phpstan-return list<array<array-key, mixed>>
+     */
     public function dataProviderForTestConnection(): array
     {
         return [
@@ -452,6 +464,9 @@ class IbexaSolrExtensionExtensionTest extends AbstractExtensionTestCase
         );
     }
 
+    /**
+     * @phpstan-return list<array{array<string, mixed>, array<string, mixed>}>
+     */
     public function dataProvideForTestBoostFactorMap(): array
     {
         return [

--- a/tests/bundle/Gateway/UpdateSerializer/JsonUpdateSerializerTest.php
+++ b/tests/bundle/Gateway/UpdateSerializer/JsonUpdateSerializerTest.php
@@ -38,7 +38,7 @@ class JsonUpdateSerializerTest extends TestCase
     ];
 
     /** @var \Ibexa\Solr\Gateway\UpdateSerializer\JsonUpdateSerializer */
-    private $serializer;
+    private JsonUpdateSerializer $serializer;
 
     public function getDataForTestSerialize(): iterable
     {

--- a/tests/lib/Container/Compiler/AggregateCriterionVisitorPassTest.php
+++ b/tests/lib/Container/Compiler/AggregateCriterionVisitorPassTest.php
@@ -35,7 +35,7 @@ class AggregateCriterionVisitorPassTest extends AbstractCompilerPassTestCase
         $container->addCompilerPass(new AggregateCriterionVisitorPass());
     }
 
-    public function testAddVisitor()
+    public function testAddVisitor(): void
     {
         $serviceId = 'service_id';
         $def = new Definition();

--- a/tests/lib/Container/Compiler/AggregateSortClauseVisitorPassTest.php
+++ b/tests/lib/Container/Compiler/AggregateSortClauseVisitorPassTest.php
@@ -35,7 +35,7 @@ class AggregateSortClauseVisitorPassTest extends AbstractCompilerPassTestCase
         $container->addCompilerPass(new AggregateSortClauseVisitorPass());
     }
 
-    public function testAddVisitor()
+    public function testAddVisitor(): void
     {
         $serviceId = 'service_id';
         $def = new Definition();

--- a/tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
+++ b/tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
@@ -7,7 +7,9 @@
 
 namespace Ibexa\Tests\Solr\Search\FieldMapper;
 
+use Ibexa\Contracts\Core\Persistence\Content\Type;
 use Ibexa\Contracts\Core\Persistence\Content\Type as SPIContentType;
+use Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition;
 use Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition as SPIFieldDefinition;
 use Ibexa\Solr\FieldMapper\BoostFactorProvider;
 use Ibexa\Tests\Solr\Search\TestCase;
@@ -17,7 +19,7 @@ use Ibexa\Tests\Solr\Search\TestCase;
  */
 class BoostFactorProviderTest extends TestCase
 {
-    public function providerForTestGetContentFieldBoostFactor()
+    public function providerForTestGetContentFieldBoostFactor(): array
     {
         return [
             [
@@ -116,10 +118,10 @@ class BoostFactorProviderTest extends TestCase
      */
     public function testGetContentFieldBoostFactor(
         array $map,
-        $contentTypeIdentifier,
-        $fieldDefinitionIdentifier,
-        $expectedBoostFactor
-    ) {
+        string $contentTypeIdentifier,
+        string $fieldDefinitionIdentifier,
+        float $expectedBoostFactor
+    ): void {
         $provider = $this->getFieldBoostProvider($map);
 
         $boostFactor = $provider->getContentFieldBoostFactor(
@@ -130,7 +132,7 @@ class BoostFactorProviderTest extends TestCase
         self::assertEquals($expectedBoostFactor, $boostFactor);
     }
 
-    public function providerForTestGetContentMetaFieldBoostFactor()
+    public function providerForTestGetContentMetaFieldBoostFactor(): array
     {
         return [
             [
@@ -242,10 +244,10 @@ class BoostFactorProviderTest extends TestCase
      */
     public function testGetContentMetaFieldBoostFactor(
         array $map,
-        $contentTypeIdentifier,
-        $fieldName,
-        $expectedBoostFactor
-    ) {
+        string $contentTypeIdentifier,
+        string $fieldName,
+        float $expectedBoostFactor
+    ): void {
         $provider = $this->getFieldBoostProvider($map);
 
         $boostFactor = $provider->getContentMetaFieldBoostFactor(
@@ -256,12 +258,12 @@ class BoostFactorProviderTest extends TestCase
         self::assertEquals($expectedBoostFactor, $boostFactor);
     }
 
-    protected function getFieldBoostProvider(array $map)
+    protected function getFieldBoostProvider(array $map): BoostFactorProvider
     {
         return new BoostFactorProvider($map);
     }
 
-    protected function getContentTypeStub($identifier)
+    protected function getContentTypeStub($identifier): Type
     {
         return new SPIContentType(
             [
@@ -270,7 +272,7 @@ class BoostFactorProviderTest extends TestCase
         );
     }
 
-    protected function getFieldDefinitionStub($identifier)
+    protected function getFieldDefinitionStub($identifier): FieldDefinition
     {
         return new SPIFieldDefinition(
             [

--- a/tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
+++ b/tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
@@ -19,6 +19,9 @@ use Ibexa\Tests\Solr\Search\TestCase;
  */
 class BoostFactorProviderTest extends TestCase
 {
+    /**
+     * @return array{array<string, mixed>, string, string, float}[]
+     */
     public function providerForTestGetContentFieldBoostFactor(): array
     {
         return [
@@ -132,6 +135,9 @@ class BoostFactorProviderTest extends TestCase
         self::assertEquals($expectedBoostFactor, $boostFactor);
     }
 
+    /**
+     * @return array{array<string, mixed>, string, string, float}[]
+     */
     public function providerForTestGetContentMetaFieldBoostFactor(): array
     {
         return [

--- a/tests/lib/Search/FieldMapper/IndexingDepthProviderTest.php
+++ b/tests/lib/Search/FieldMapper/IndexingDepthProviderTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class IndexingDepthProviderTest extends TestCase
 {
-    public function testGetMaxDepthForContentType()
+    public function testGetMaxDepthForContentType(): void
     {
         $indexingDepthProvider = $this->createIndexingDepthProvider();
 
@@ -27,7 +27,7 @@ class IndexingDepthProviderTest extends TestCase
         ));
     }
 
-    public function testGetMaxDepthForContentTypeReturnsDefaultValue()
+    public function testGetMaxDepthForContentTypeReturnsDefaultValue(): void
     {
         $indexingDepthProvider = $this->createIndexingDepthProvider();
 
@@ -36,7 +36,7 @@ class IndexingDepthProviderTest extends TestCase
         ));
     }
 
-    public function testGetMaxDepth()
+    public function testGetMaxDepth(): void
     {
         self::assertEquals(2, $this->createIndexingDepthProvider()->getMaxDepth());
     }
@@ -49,7 +49,7 @@ class IndexingDepthProviderTest extends TestCase
         ], 0);
     }
 
-    private function getContentTypeStub($identifier): SPIContentType
+    private function getContentTypeStub(string $identifier): SPIContentType
     {
         return new SPIContentType([
             'identifier' => $identifier,

--- a/tests/lib/Search/Gateway/DistributionStrategy/CloudDistributionStrategyTest.php
+++ b/tests/lib/Search/Gateway/DistributionStrategy/CloudDistributionStrategyTest.php
@@ -12,18 +12,19 @@ use Ibexa\Solr\Gateway\DistributionStrategy\CloudDistributionStrategy;
 use Ibexa\Solr\Gateway\Endpoint;
 use Ibexa\Solr\Gateway\EndpointRegistry;
 use Ibexa\Solr\Gateway\EndpointResolver;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class CloudDistributionStrategyTest extends TestCase
 {
     /** @var \Ibexa\Solr\Gateway\DistributionStrategy\CloudDistributionStrategy */
-    private $distributionStrategy;
+    private CloudDistributionStrategy $distributionStrategy;
 
     /** @var \Ibexa\Solr\Gateway\EndpointResolver|\PHPUnit\Framework\MockObject\MockObject */
-    private $endpointResolver;
+    private MockObject $endpointResolver;
 
     /** @var \Ibexa\Solr\Gateway\EndpointRegistry|\PHPUnit\Framework\MockObject\MockObject */
-    private $endpointRegistry;
+    private MockObject $endpointRegistry;
 
     protected function setUp(): void
     {
@@ -32,7 +33,7 @@ class CloudDistributionStrategyTest extends TestCase
         $this->endpointRegistry = $this->createMock(EndpointRegistry::class);
         $this->endpointRegistry
             ->method('getEndpoint')
-            ->willReturnCallback(static function ($name) {
+            ->willReturnCallback(static function (string $name): Endpoint {
                 return new Endpoint([
                     'core' => 'collection_' . $name,
                 ]);

--- a/tests/lib/Search/Gateway/DistributionStrategy/StandaloneDistributionStrategyTest.php
+++ b/tests/lib/Search/Gateway/DistributionStrategy/StandaloneDistributionStrategyTest.php
@@ -18,13 +18,13 @@ use PHPUnit\Framework\TestCase;
 class StandaloneDistributionStrategyTest extends TestCase
 {
     /** @var \Ibexa\Solr\Gateway\DistributionStrategy\StandaloneDistributionStrategy */
-    private $distributionStrategy;
+    private StandaloneDistributionStrategy $distributionStrategy;
 
     /** @var \Ibexa\Solr\Gateway\EndpointRegistry|\PHPUnit\Framework\MockObject\MockObject */
-    private $endpointRegistry;
+    private MockObject $endpointRegistry;
 
     /** @var \Ibexa\Solr\Gateway\EndpointResolver|\PHPUnit\Framework\MockObject\MockObject */
-    private $endpointResolver;
+    private MockObject $endpointResolver;
 
     protected function setUp(): void
     {
@@ -85,7 +85,7 @@ class StandaloneDistributionStrategyTest extends TestCase
         $endpointRegistry = $this->createMock(EndpointRegistry::class);
         $endpointRegistry
             ->method('getEndpoint')
-            ->willReturnCallback(function ($name) {
+            ->willReturnCallback(function ($name): MockObject {
                 $endpoint = $this->createMock(Endpoint::class);
                 $endpoint->method('getIdentifier')->willReturn('127.0.0.' . \ord($name) . ':8983/solr/collection1');
 

--- a/tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
+++ b/tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
@@ -830,6 +830,9 @@ class NativeEndpointResolverTest extends TestCase
         }
     }
 
+    /**
+     * @return array{string[], string|null, string|null, array<string, mixed>, string}[]
+     */
     public function providerForTestGetSearchTargetsThrowsRuntimeException(): array
     {
         return [
@@ -947,6 +950,9 @@ class NativeEndpointResolverTest extends TestCase
         }
     }
 
+    /**
+     * @return array{string[], string|null, string|null, string[]}[]
+     */
     public function providerForTestGetEndpoints(): array
     {
         return [

--- a/tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
+++ b/tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
@@ -924,7 +924,7 @@ class NativeEndpointResolverTest extends TestCase
      */
     public function testGetSearchTargetsThrowsRuntimeException(
         array $endpointMap,
-        $defaultEndpoint,
+        ?string $defaultEndpoint,
         ?string $mainLanguagesEndpoint,
         array $languageSettings,
         string $message

--- a/tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
+++ b/tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
@@ -17,7 +17,7 @@ use RuntimeException;
  */
 class NativeEndpointResolverTest extends TestCase
 {
-    public function testGetEntryEndpoint()
+    public function testGetEntryEndpoint(): void
     {
         $entryEndpoints = [
             'endpoint2',
@@ -33,7 +33,7 @@ class NativeEndpointResolverTest extends TestCase
         );
     }
 
-    public function testGetEntryEndpointThrowsRuntimeException()
+    public function testGetEntryEndpointThrowsRuntimeException(): void
     {
         $this->expectException(RuntimeException::class);
         $entryEndpoints = [];
@@ -43,7 +43,7 @@ class NativeEndpointResolverTest extends TestCase
         $endpointResolver->getEntryEndpoint();
     }
 
-    public function testGetIndexingTarget()
+    public function testGetIndexingTarget(): void
     {
         $endpointMap = [
             'eng-GB' => 'endpoint3',
@@ -57,7 +57,7 @@ class NativeEndpointResolverTest extends TestCase
         );
     }
 
-    public function testGetIndexingTargetReturnsDefaultEndpoint()
+    public function testGetIndexingTargetReturnsDefaultEndpoint(): void
     {
         $endpointMap = [];
         $defaultEndpoint = 'endpoint4';
@@ -70,14 +70,14 @@ class NativeEndpointResolverTest extends TestCase
         );
     }
 
-    public function getIndexingTargetThrowsRuntimeException()
+    public function getIndexingTargetThrowsRuntimeException(): void
     {
         $endpointResolver = $this->getEndpointResolver();
 
         $endpointResolver->getIndexingTarget('ger-DE');
     }
 
-    public function testGetMainLanguagesEndpoint()
+    public function testGetMainLanguagesEndpoint(): void
     {
         $mainLanguagesEndpoint = 'endpoint5';
 
@@ -89,14 +89,14 @@ class NativeEndpointResolverTest extends TestCase
         );
     }
 
-    public function testGetMainLanguagesEndpointReturnsNull()
+    public function testGetMainLanguagesEndpointReturnsNull(): void
     {
         $endpointResolver = $this->getEndpointResolver();
 
         self::assertNull($endpointResolver->getMainLanguagesEndpoint());
     }
 
-    public function providerForTestGetSearchTargets()
+    public function providerForTestGetSearchTargets(): array
     {
         return [
             // Will return all endpoints (for always available fallback without main languages endpoint)
@@ -807,13 +807,13 @@ class NativeEndpointResolverTest extends TestCase
      * @param bool $expectedIsMultiple
      */
     public function testGetSearchTargets(
-        $endpointMap,
-        $defaultEndpoint,
-        $mainLanguagesEndpoint,
-        $languageSettings,
-        $expected,
-        $expectedIsMultiple = true
-    ) {
+        array $endpointMap,
+        ?string $defaultEndpoint,
+        ?string $mainLanguagesEndpoint,
+        array $languageSettings,
+        array $expected,
+        bool $expectedIsMultiple = true
+    ): void {
         $endpointResolver = $this->getEndpointResolver(
             [],
             $endpointMap,
@@ -830,7 +830,7 @@ class NativeEndpointResolverTest extends TestCase
         }
     }
 
-    public function providerForTestGetSearchTargetsThrowsRuntimeException()
+    public function providerForTestGetSearchTargetsThrowsRuntimeException(): array
     {
         return [
             // Will try to return all endpoints
@@ -923,12 +923,12 @@ class NativeEndpointResolverTest extends TestCase
      * @param string $message
      */
     public function testGetSearchTargetsThrowsRuntimeException(
-        $endpointMap,
+        array $endpointMap,
         $defaultEndpoint,
-        $mainLanguagesEndpoint,
-        $languageSettings,
-        $message
-    ) {
+        ?string $mainLanguagesEndpoint,
+        array $languageSettings,
+        string $message
+    ): void {
         $this->expectException(RuntimeException::class);
 
         $endpointResolver = $this->getEndpointResolver(
@@ -947,7 +947,7 @@ class NativeEndpointResolverTest extends TestCase
         }
     }
 
-    public function providerForTestGetEndpoints()
+    public function providerForTestGetEndpoints(): array
     {
         return [
             [
@@ -1020,11 +1020,11 @@ class NativeEndpointResolverTest extends TestCase
      * @param string[] $expected
      */
     public function testGetEndpoints(
-        $endpointMap,
-        $defaultEndpoint,
-        $mainLanguagesEndpoint,
-        $expected
-    ) {
+        array $endpointMap,
+        ?string $defaultEndpoint,
+        ?string $mainLanguagesEndpoint,
+        array $expected
+    ): void {
         $endpointResolver = $this->getEndpointResolver(
             [],
             $endpointMap,
@@ -1037,7 +1037,7 @@ class NativeEndpointResolverTest extends TestCase
         self::assertEquals($expected, $endpoints);
     }
 
-    public function testGetEndpointsThrowsRuntimeException()
+    public function testGetEndpointsThrowsRuntimeException(): void
     {
         $this->expectException(RuntimeException::class);
         $endpointResolver = $this->getEndpointResolver(
@@ -1055,7 +1055,7 @@ class NativeEndpointResolverTest extends TestCase
         array $endpointMap = [],
         $defaultEndpoint = null,
         $mainLanguagesEndpoint = null
-    ) {
+    ): NativeEndpointResolver {
         return new NativeEndpointResolver(
             $entryEndpoints,
             $endpointMap,

--- a/tests/lib/Search/Gateway/EndpointTest.php
+++ b/tests/lib/Search/Gateway/EndpointTest.php
@@ -16,7 +16,7 @@ use Ibexa\Tests\Solr\Search\TestCase;
  */
 class EndpointTest extends TestCase
 {
-    public function testEndpointDsnParsingWithAll()
+    public function testEndpointDsnParsingWithAll(): void
     {
         $actual = new Endpoint(['dsn' => 'https://jura:pura@10.10.10.10:5434/jolr', 'core' => 'core0']);
         $expected = new Endpoint([
@@ -32,7 +32,7 @@ class EndpointTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    public function testEndpointDsnParsingWithoutUser()
+    public function testEndpointDsnParsingWithoutUser(): void
     {
         $actual = new Endpoint(['dsn' => 'https://10.10.10.10:5434/jolr', 'core' => 'core0']);
         $expected = new Endpoint([
@@ -48,7 +48,7 @@ class EndpointTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    public function testEndpointDsnParsingWithFragment()
+    public function testEndpointDsnParsingWithFragment(): void
     {
         $actual = new Endpoint(['dsn' => 'https://10.10.10.10:5434/jolr#core1']);
         $expected = new Endpoint([
@@ -64,7 +64,7 @@ class EndpointTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    public function testEndpointDsnParsingOverridesAllIfSet()
+    public function testEndpointDsnParsingOverridesAllIfSet(): void
     {
         $actual = new Endpoint([
             'dsn' => 'https://jura:pura@10.10.10.10:5434/jolr#core1',
@@ -89,7 +89,7 @@ class EndpointTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    public function testEndpointDsnParsingWithQuery()
+    public function testEndpointDsnParsingWithQuery(): void
     {
         $this->expectException(PropertyNotFoundException::class);
 

--- a/tests/lib/Search/Query/Common/AggregationVisitor/AbstractAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/AbstractAggregationVisitorTest.php
@@ -10,6 +10,7 @@ namespace Ibexa\Tests\Solr\Search\Query\Common\AggregationVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation;
 use Ibexa\Contracts\Solr\Query\AggregationVisitor;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 abstract class AbstractAggregationVisitorTest extends TestCase
@@ -22,7 +23,7 @@ abstract class AbstractAggregationVisitorTest extends TestCase
     protected $visitor;
 
     /** @var \Ibexa\Contracts\Solr\Query\AggregationVisitor|\PHPUnit\Framework\MockObject\MockObject */
-    protected $dispatcherVisitor;
+    protected MockObject $dispatcherVisitor;
 
     protected function setUp(): void
     {

--- a/tests/lib/Search/Query/Common/AggregationVisitor/RangeAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/RangeAggregationVisitorTest.php
@@ -14,11 +14,12 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range;
 use Ibexa\Contracts\Solr\Query\AggregationVisitor;
 use Ibexa\Contracts\Solr\Query\Common\AggregationVisitor\AggregationFieldResolver;
 use Ibexa\Solr\Query\Common\AggregationVisitor\RangeAggregationVisitor;
+use PHPUnit\Framework\MockObject\MockObject;
 
 final class RangeAggregationVisitorTest extends AbstractAggregationVisitorTest
 {
     /** @var \Ibexa\Contracts\Solr\Query\Common\AggregationVisitor\AggregationFieldResolver|\PHPUnit\Framework\MockObject\MockObject */
-    private $aggregationFieldResolver;
+    private MockObject $aggregationFieldResolver;
 
     protected function setUp(): void
     {

--- a/tests/lib/Search/Query/Common/AggregationVisitor/StatsAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/StatsAggregationVisitorTest.php
@@ -13,11 +13,12 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\AbstractSta
 use Ibexa\Contracts\Solr\Query\AggregationVisitor;
 use Ibexa\Contracts\Solr\Query\Common\AggregationVisitor\AggregationFieldResolver;
 use Ibexa\Solr\Query\Common\AggregationVisitor\StatsAggregationVisitor;
+use PHPUnit\Framework\MockObject\MockObject;
 
 final class StatsAggregationVisitorTest extends AbstractAggregationVisitorTest
 {
     /** @var \Ibexa\Contracts\Solr\Query\Common\AggregationVisitor\AggregationFieldResolver|\PHPUnit\Framework\MockObject\MockObject */
-    private $aggregationFieldResolver;
+    private MockObject $aggregationFieldResolver;
 
     protected function setUp(): void
     {

--- a/tests/lib/Search/Query/Common/AggregationVisitor/TermAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/TermAggregationVisitorTest.php
@@ -13,11 +13,12 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\AbstractTer
 use Ibexa\Contracts\Solr\Query\AggregationVisitor;
 use Ibexa\Contracts\Solr\Query\Common\AggregationVisitor\AggregationFieldResolver;
 use Ibexa\Solr\Query\Common\AggregationVisitor\TermAggregationVisitor;
+use PHPUnit\Framework\MockObject\MockObject;
 
 final class TermAggregationVisitorTest extends AbstractAggregationVisitorTest
 {
     /** @var \Ibexa\Contracts\Solr\Query\Common\AggregationVisitor\AggregationFieldResolver|\PHPUnit\Framework\MockObject\MockObject */
-    private $aggregationFieldResolver;
+    private MockObject $aggregationFieldResolver;
 
     protected function setUp(): void
     {

--- a/tests/lib/Search/Query/Common/AggregationVisitor/TermAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/TermAggregationVisitorTest.php
@@ -17,8 +17,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 final class TermAggregationVisitorTest extends AbstractAggregationVisitorTest
 {
-    /** @var \Ibexa\Contracts\Solr\Query\Common\AggregationVisitor\AggregationFieldResolver|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $aggregationFieldResolver;
+    private AggregationFieldResolver&MockObject $aggregationFieldResolver;
 
     protected function setUp(): void
     {

--- a/tests/lib/Search/Query/Content/CriterionVisitor/FullTextTest.php
+++ b/tests/lib/Search/Query/Content/CriterionVisitor/FullTextTest.php
@@ -15,6 +15,7 @@ use Ibexa\Solr\Query\Common\QueryTranslator\Generator\WordVisitor;
 use Ibexa\Solr\Query\Content\CriterionVisitor\FullText;
 use Ibexa\Tests\Solr\Search\TestCase;
 use QueryTranslator\Languages\Galach\Generators;
+use QueryTranslator\Languages\Galach\Generators\ExtendedDisMax;
 use QueryTranslator\Languages\Galach\Parser;
 use QueryTranslator\Languages\Galach\TokenExtractor\Text;
 use QueryTranslator\Languages\Galach\Tokenizer;
@@ -26,7 +27,7 @@ use QueryTranslator\Languages\Galach\Tokenizer;
  */
 class FullTextTest extends TestCase
 {
-    protected function getFullTextCriterionVisitor(array $fieldTypes = [], int $maxDepth = 0)
+    protected function getFullTextCriterionVisitor(array $fieldTypes = [], int $maxDepth = 0): FullText
     {
         $fieldNameResolver = $this->getMockBuilder(FieldNameResolver::class)
             ->disableOriginalConstructor()
@@ -57,7 +58,7 @@ class FullTextTest extends TestCase
     /**
      * @return \QueryTranslator\Languages\Galach\Tokenizer
      */
-    protected function getTokenizer()
+    protected function getTokenizer(): Tokenizer
     {
         return new Tokenizer(
             new Text()
@@ -67,7 +68,7 @@ class FullTextTest extends TestCase
     /**
      * @return \QueryTranslator\Languages\Galach\Parser
      */
-    protected function getParser()
+    protected function getParser(): Parser
     {
         return new Parser();
     }
@@ -75,9 +76,9 @@ class FullTextTest extends TestCase
     /**
      * @return \QueryTranslator\Languages\Galach\Generators\ExtendedDisMax
      */
-    protected function getGenerator()
+    protected function getGenerator(): ExtendedDisMax
     {
-        return new Generators\ExtendedDisMax(
+        return new ExtendedDisMax(
             new Generators\Common\Aggregate(
                 [
                     new Generators\Lucene\Common\Group(),
@@ -96,7 +97,7 @@ class FullTextTest extends TestCase
         );
     }
 
-    public function testVisitSimple()
+    public function testVisitSimple(): void
     {
         $visitor = $this->getFullTextCriterionVisitor();
 
@@ -108,7 +109,7 @@ class FullTextTest extends TestCase
         );
     }
 
-    public function testVisitSimpleMultipleWords()
+    public function testVisitSimpleMultipleWords(): void
     {
         $visitor = $this->getFullTextCriterionVisitor();
 
@@ -120,7 +121,7 @@ class FullTextTest extends TestCase
         );
     }
 
-    public function testVisitFuzzy()
+    public function testVisitFuzzy(): void
     {
         $visitor = $this->getFullTextCriterionVisitor();
 
@@ -133,7 +134,7 @@ class FullTextTest extends TestCase
         );
     }
 
-    public function testVisitFuzzyMultipleWords()
+    public function testVisitFuzzyMultipleWords(): void
     {
         $visitor = $this->getFullTextCriterionVisitor();
 
@@ -146,7 +147,7 @@ class FullTextTest extends TestCase
         );
     }
 
-    public function testVisitBoost()
+    public function testVisitBoost(): void
     {
         $ftTextLine = new SearchField();
         $visitor = $this->getFullTextCriterionVisitor(
@@ -165,7 +166,7 @@ class FullTextTest extends TestCase
         );
     }
 
-    public function testVisitBoostMultipleWords()
+    public function testVisitBoostMultipleWords(): void
     {
         $ftTextLine = new SearchField();
         $visitor = $this->getFullTextCriterionVisitor(
@@ -184,7 +185,7 @@ class FullTextTest extends TestCase
         );
     }
 
-    public function testVisitBoostUnknownField()
+    public function testVisitBoostUnknownField(): void
     {
         $visitor = $this->getFullTextCriterionVisitor();
 
@@ -199,7 +200,7 @@ class FullTextTest extends TestCase
         );
     }
 
-    public function testVisitBoostUnknownFieldMultipleWords()
+    public function testVisitBoostUnknownFieldMultipleWords(): void
     {
         $visitor = $this->getFullTextCriterionVisitor();
 
@@ -214,7 +215,7 @@ class FullTextTest extends TestCase
         );
     }
 
-    public function testVisitFuzzyBoost()
+    public function testVisitFuzzyBoost(): void
     {
         $stringField = new StringField();
         $visitor = $this->getFullTextCriterionVisitor(
@@ -233,7 +234,7 @@ class FullTextTest extends TestCase
         );
     }
 
-    public function testVisitFuzzyBoostMultipleWords()
+    public function testVisitFuzzyBoostMultipleWords(): void
     {
         $stringField = new StringField();
         $visitor = $this->getFullTextCriterionVisitor(
@@ -252,7 +253,7 @@ class FullTextTest extends TestCase
         );
     }
 
-    public function testVisitErrorCorrection()
+    public function testVisitErrorCorrection(): void
     {
         $visitor = $this->getFullTextCriterionVisitor();
 
@@ -264,7 +265,7 @@ class FullTextTest extends TestCase
         );
     }
 
-    public function testVisitWithRelated()
+    public function testVisitWithRelated(): void
     {
         $visitor = $this->getFullTextCriterionVisitor([], 3);
 

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/NestedAggregationResultExtractorTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/NestedAggregationResultExtractorTest.php
@@ -12,6 +12,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation;
 use Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult;
 use Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor;
 use Ibexa\Solr\ResultExtractor\AggregationResultExtractor\NestedAggregationResultExtractor;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -20,10 +21,10 @@ final class NestedAggregationResultExtractorTest extends TestCase
     private const EXAMPLE_NESTED_RESULT_KEY = 'foo';
 
     /** @var \Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor|\PHPUnit\Framework\MockObject\MockObject */
-    private $innerResultExtractor;
+    private MockObject $innerResultExtractor;
 
     /** @var \Ibexa\Solr\ResultExtractor\AggregationResultExtractor\NestedAggregationResultExtractor */
-    private $resultExtractor;
+    private NestedAggregationResultExtractor $resultExtractor;
 
     protected function setUp(): void
     {

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/NestedAggregationResultExtractorTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/NestedAggregationResultExtractorTest.php
@@ -20,10 +20,8 @@ final class NestedAggregationResultExtractorTest extends TestCase
 {
     private const EXAMPLE_NESTED_RESULT_KEY = 'foo';
 
-    /** @var \Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $innerResultExtractor;
+    private AggregationResultExtractor&MockObject $innerResultExtractor;
 
-    /** @var \Ibexa\Solr\ResultExtractor\AggregationResultExtractor\NestedAggregationResultExtractor */
     private NestedAggregationResultExtractor $resultExtractor;
 
     protected function setUp(): void

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/RangeAggregationResultExtractorTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/RangeAggregationResultExtractorTest.php
@@ -21,8 +21,7 @@ use stdClass;
 
 final class RangeAggregationResultExtractorTest extends AbstractAggregationResultExtractorTest
 {
-    /** @var \Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $keyMapper;
+    private RangeAggregationKeyMapper&MockObject $keyMapper;
 
     protected function setUp(): void
     {

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/RangeAggregationResultExtractorTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/RangeAggregationResultExtractorTest.php
@@ -16,12 +16,13 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\Rang
 use Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor;
 use Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper;
 use Ibexa\Solr\ResultExtractor\AggregationResultExtractor\RangeAggregationResultExtractor;
+use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 
 final class RangeAggregationResultExtractorTest extends AbstractAggregationResultExtractorTest
 {
     /** @var \Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper|\PHPUnit\Framework\MockObject\MockObject */
-    private $keyMapper;
+    private MockObject $keyMapper;
 
     protected function setUp(): void
     {

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeAggregationKeyMapperTest.php
@@ -13,6 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
 use Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\ContentTypeAggregationKeyMapper;
 use Ibexa\Tests\Solr\Search\ResultExtractor\AggregationResultExtractor\AggregationResultExtractorTestUtils;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class ContentTypeAggregationKeyMapperTest extends TestCase
@@ -20,7 +21,7 @@ final class ContentTypeAggregationKeyMapperTest extends TestCase
     private const EXAMPLE_CONTENT_TYPE_IDS = [1, 2, 3];
 
     /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService|\PHPUnit\Framework\MockObject\MockObject */
-    private $contentTypeService;
+    private MockObject $contentTypeService;
 
     protected function setUp(): void
     {

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeAggregationKeyMapperTest.php
@@ -20,8 +20,7 @@ final class ContentTypeAggregationKeyMapperTest extends TestCase
 {
     private const EXAMPLE_CONTENT_TYPE_IDS = [1, 2, 3];
 
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $contentTypeService;
+    private ContentTypeService&MockObject $contentTypeService;
 
     protected function setUp(): void
     {

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeGroupAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeGroupAggregationKeyMapperTest.php
@@ -13,6 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup;
 use Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\ContentTypeGroupAggregationKeyMapper;
 use Ibexa\Tests\Solr\Search\ResultExtractor\AggregationResultExtractor\AggregationResultExtractorTestUtils;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class ContentTypeGroupAggregationKeyMapperTest extends TestCase
@@ -20,7 +21,7 @@ final class ContentTypeGroupAggregationKeyMapperTest extends TestCase
     private const EXAMPLE_CONTENT_TYPE_GROUPS_IDS = ['1', '2', '3'];
 
     /** @var \PHPUnit\Framework\MockObject\MockObject */
-    private $contentTypeService;
+    private MockObject $contentTypeService;
 
     protected function setUp(): void
     {

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeGroupAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeGroupAggregationKeyMapperTest.php
@@ -20,8 +20,7 @@ final class ContentTypeGroupAggregationKeyMapperTest extends TestCase
 {
     private const EXAMPLE_CONTENT_TYPE_GROUPS_IDS = ['1', '2', '3'];
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $contentTypeService;
+    private ContentTypeService&MockObject $contentTypeService;
 
     protected function setUp(): void
     {

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LanguageAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LanguageAggregationKeyMapperTest.php
@@ -20,10 +20,8 @@ final class LanguageAggregationKeyMapperTest extends TestCase
 {
     private const EXAMPLE_LANGUAGE_CODES = [];
 
-    /** @var \Ibexa\Contracts\Core\Repository\LanguageService|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $languageService;
+    private LanguageService&MockObject $languageService;
 
-    /** @var \Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\CountryAggregationKeyMapper */
     private LanguageAggregationKeyMapper $mapper;
 
     protected function setUp(): void

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LanguageAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LanguageAggregationKeyMapperTest.php
@@ -13,6 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Language;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation;
 use Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\LanguageAggregationKeyMapper;
 use Ibexa\Tests\Solr\Search\ResultExtractor\AggregationResultExtractor\AggregationResultExtractorTestUtils;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class LanguageAggregationKeyMapperTest extends TestCase
@@ -20,10 +21,10 @@ final class LanguageAggregationKeyMapperTest extends TestCase
     private const EXAMPLE_LANGUAGE_CODES = [];
 
     /** @var \Ibexa\Contracts\Core\Repository\LanguageService|\PHPUnit\Framework\MockObject\MockObject */
-    private $languageService;
+    private MockObject $languageService;
 
     /** @var \Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\CountryAggregationKeyMapper */
-    private $mapper;
+    private LanguageAggregationKeyMapper $mapper;
 
     protected function setUp(): void
     {

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LocationAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LocationAggregationKeyMapperTest.php
@@ -13,6 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation;
 use Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\LocationAggregationKeyMapper;
 use Ibexa\Tests\Solr\Search\ResultExtractor\AggregationResultExtractor\AggregationResultExtractorTestUtils;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class LocationAggregationKeyMapperTest extends TestCase
@@ -20,10 +21,10 @@ final class LocationAggregationKeyMapperTest extends TestCase
     private const EXAMPLE_LOCATION_IDS = ['2', '54', '47'];
 
     /** @var \Ibexa\Contracts\Core\Repository\LocationService|\PHPUnit\Framework\MockObject\MockObject */
-    private $locationService;
+    private MockObject $locationService;
 
     /** @var \Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\LocationAggregationKeyMapper */
-    private $mapper;
+    private LocationAggregationKeyMapper $mapper;
 
     protected function setUp(): void
     {

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LocationAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LocationAggregationKeyMapperTest.php
@@ -20,10 +20,8 @@ final class LocationAggregationKeyMapperTest extends TestCase
 {
     private const EXAMPLE_LOCATION_IDS = ['2', '54', '47'];
 
-    /** @var \Ibexa\Contracts\Core\Repository\LocationService|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $locationService;
+    private LocationService&MockObject $locationService;
 
-    /** @var \Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\LocationAggregationKeyMapper */
     private LocationAggregationKeyMapper $mapper;
 
     protected function setUp(): void

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ObjectStateAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ObjectStateAggregationKeyMapperTest.php
@@ -19,10 +19,8 @@ use PHPUnit\Framework\TestCase;
 
 final class ObjectStateAggregationKeyMapperTest extends TestCase
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ObjectStateService|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $objectStateService;
+    private ObjectStateService&MockObject $objectStateService;
 
-    /** @var \Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\ObjectStateAggregationKeyMapper */
     private ObjectStateAggregationKeyMapper $mapper;
 
     protected function setUp(): void

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ObjectStateAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ObjectStateAggregationKeyMapperTest.php
@@ -14,15 +14,16 @@ use Ibexa\Contracts\Core\Repository\Values\ObjectState\ObjectState;
 use Ibexa\Contracts\Core\Repository\Values\ObjectState\ObjectStateGroup;
 use Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\ObjectStateAggregationKeyMapper;
 use Ibexa\Tests\Solr\Search\ResultExtractor\AggregationResultExtractor\AggregationResultExtractorTestUtils;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class ObjectStateAggregationKeyMapperTest extends TestCase
 {
     /** @var \Ibexa\Contracts\Core\Repository\ObjectStateService|\PHPUnit\Framework\MockObject\MockObject */
-    private $objectStateService;
+    private MockObject $objectStateService;
 
     /** @var \Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\ObjectStateAggregationKeyMapper */
-    private $mapper;
+    private ObjectStateAggregationKeyMapper $mapper;
 
     protected function setUp(): void
     {

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SectionAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SectionAggregationKeyMapperTest.php
@@ -13,6 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation;
 use Ibexa\Contracts\Core\Repository\Values\Content\Section;
 use Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\SectionAggregationKeyMapper;
 use Ibexa\Tests\Solr\Search\ResultExtractor\AggregationResultExtractor\AggregationResultExtractorTestUtils;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class SectionAggregationKeyMapperTest extends TestCase
@@ -20,10 +21,10 @@ final class SectionAggregationKeyMapperTest extends TestCase
     private const EXAMPLE_SECTION_IDS = [1, 2, 3];
 
     /** @var \Ibexa\Contracts\Core\Repository\SectionService|\PHPUnit\Framework\MockObject\MockObject */
-    private $sectionService;
+    private MockObject $sectionService;
 
     /** @var \Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\SectionAggregationKeyMapper */
-    private $mapper;
+    private SectionAggregationKeyMapper $mapper;
 
     protected function setUp(): void
     {

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SectionAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SectionAggregationKeyMapperTest.php
@@ -20,10 +20,8 @@ final class SectionAggregationKeyMapperTest extends TestCase
 {
     private const EXAMPLE_SECTION_IDS = [1, 2, 3];
 
-    /** @var \Ibexa\Contracts\Core\Repository\SectionService|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $sectionService;
+    private SectionService&MockObject $sectionService;
 
-    /** @var \Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\SectionAggregationKeyMapper */
     private SectionAggregationKeyMapper $mapper;
 
     protected function setUp(): void

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SubtreeAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SubtreeAggregationKeyMapperTest.php
@@ -20,8 +20,7 @@ final class SubtreeAggregationKeyMapperTest extends TestCase
 {
     private const EXAMPLE_PATH_STRING = '/1/2/54/';
 
-    /** @var \Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $locationAggregationKeyMapper;
+    private TermAggregationKeyMapper&MockObject $locationAggregationKeyMapper;
 
     protected function setUp(): void
     {

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SubtreeAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SubtreeAggregationKeyMapperTest.php
@@ -13,6 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Location\Su
 use Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
 use Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\SubtreeAggregationKeyMapper;
 use Ibexa\Tests\Solr\Search\ResultExtractor\AggregationResultExtractor\AggregationResultExtractorTestUtils;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class SubtreeAggregationKeyMapperTest extends TestCase
@@ -20,7 +21,7 @@ final class SubtreeAggregationKeyMapperTest extends TestCase
     private const EXAMPLE_PATH_STRING = '/1/2/54/';
 
     /** @var \Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper|\PHPUnit\Framework\MockObject\MockObject */
-    private $locationAggregationKeyMapper;
+    private MockObject $locationAggregationKeyMapper;
 
     protected function setUp(): void
     {

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/UserMetadataAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/UserMetadataAggregationKeyMapperTest.php
@@ -15,6 +15,7 @@ use Ibexa\Contracts\Core\Repository\Values\User\User;
 use Ibexa\Contracts\Core\Repository\Values\User\UserGroup;
 use Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\UserMetadataAggregationKeyMapper;
 use Ibexa\Tests\Solr\Search\ResultExtractor\AggregationResultExtractor\AggregationResultExtractorTestUtils;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class UserMetadataAggregationKeyMapperTest extends TestCase
@@ -23,10 +24,10 @@ final class UserMetadataAggregationKeyMapperTest extends TestCase
     private const EXAMPLE_USER_GROUP_IDS = [1, 2, 3];
 
     /** @var \Ibexa\Contracts\Core\Repository\UserService|\PHPUnit\Framework\MockObject\MockObject */
-    private $userService;
+    private MockObject $userService;
 
     /** @var \Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\UserMetadataAggregationKeyMapper */
-    private $mapper;
+    private UserMetadataAggregationKeyMapper $mapper;
 
     protected function setUp(): void
     {

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/UserMetadataAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/UserMetadataAggregationKeyMapperTest.php
@@ -23,8 +23,7 @@ final class UserMetadataAggregationKeyMapperTest extends TestCase
     private const EXAMPLE_USER_IDS = [1, 2, 3];
     private const EXAMPLE_USER_GROUP_IDS = [1, 2, 3];
 
-    /** @var \Ibexa\Contracts\Core\Repository\UserService|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $userService;
+    private UserService&MockObject $userService;
 
     /** @var \Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\UserMetadataAggregationKeyMapper */
     private UserMetadataAggregationKeyMapper $mapper;

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationResultExtractorTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationResultExtractorTest.php
@@ -20,8 +20,7 @@ use stdClass;
 
 final class TermAggregationResultExtractorTest extends AbstractAggregationResultExtractorTest
 {
-    /** @var \Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $keyMapper;
+    private TermAggregationKeyMapper&MockObject $keyMapper;
 
     protected function setUp(): void
     {

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationResultExtractorTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationResultExtractorTest.php
@@ -15,12 +15,13 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\Term
 use Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor;
 use Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
 use Ibexa\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor;
+use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 
 final class TermAggregationResultExtractorTest extends AbstractAggregationResultExtractorTest
 {
     /** @var \Ibexa\Contracts\Solr\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper|\PHPUnit\Framework\MockObject\MockObject */
-    private $keyMapper;
+    private MockObject $keyMapper;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
> [!CAUTION]
> These changes are volatile and - in some repositories - extensive, so they need to be carefully reviewed before merging.

| :ticket: Issue | IBX-9727 |
|----------------|-----------|

#### Description:

Added missing strict type hints using `\Rector\Set\ValueObject\SetList::TYPE_DECLARATION` set.
Additionally FQCNs have been imported for every affected file using PHP CS Fixer, in some cases they might override unrelated lines.

#### For QA:

Regression tests.
