### PR TITLE
IBX-9968: Resolved Symfony 7.x deprecations

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -22,4 +22,7 @@ return RectorConfig::configure()
         SymfonySetList::SYMFONY_62,
         SymfonySetList::SYMFONY_63,
         SymfonySetList::SYMFONY_64,
+        SymfonySetList::SYMFONY_70,
+        SymfonySetList::SYMFONY_71,
+        SymfonySetList::SYMFONY_72,
     ]);

--- a/src/lib/Resources/config/container/solr/aggregation_result_extractors.yml
+++ b/src/lib/Resources/config/container/solr/aggregation_result_extractors.yml
@@ -7,12 +7,12 @@ services:
   ibexa.solr.query.content.aggregation_result_extractor.dispatcher:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\DispatcherAggregationResultExtractor
     arguments:
-      $extractors: !tagged ibexa.search.solr.query.content.aggregation.result.extractor
+      $extractors: !tagged_iterator ibexa.search.solr.query.content.aggregation.result.extractor
 
   ibexa.solr.query.location.aggregation_result_extractor.dispatcher:
     class: Ibexa\Solr\ResultExtractor\AggregationResultExtractor\DispatcherAggregationResultExtractor
     arguments:
-      $extractors: !tagged ibexa.search.solr.query.location.aggregation.result.extractor
+      $extractors: !tagged_iterator ibexa.search.solr.query.location.aggregation.result.extractor
 
   ### Key mappers
 

--- a/src/lib/Resources/config/container/solr/aggregation_visitors.yml
+++ b/src/lib/Resources/config/container/solr/aggregation_visitors.yml
@@ -7,12 +7,12 @@ services:
   ibexa.solr.query.content.aggregation_visitor.dispatcher:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\DispatcherAggregationVisitor
     arguments:
-      $visitors: !tagged ibexa.search.solr.query.content.aggregation.visitor
+      $visitors: !tagged_iterator ibexa.search.solr.query.content.aggregation.visitor
 
   ibexa.solr.query.location.aggregation_visitor.dispatcher:
     class: Ibexa\Solr\Query\Common\AggregationVisitor\DispatcherAggregationVisitor
     arguments:
-      $visitors: !tagged ibexa.search.solr.query.location.aggregation.visitor
+      $visitors: !tagged_iterator ibexa.search.solr.query.location.aggregation.visitor
 
   ### Factories
 


### PR DESCRIPTION
| :ticket: Issue | IBX-9968  |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Enabled Rector Symfony 7.0, 7.1 and 7.2 sets. Resolved the following deprecations:

```
* [symfony/http-kernel] Replaced usage of internal Symfony\Component\HttpKernel\DependencyInjection\Extension class
```

#### For QA:

Sanities.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
