### PR TITLE
Added stricter type hints and update PHPUnit test mocks for improved type safety across various classes and test cases.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -757,12 +757,6 @@ parameters:
 			path: src/lib/Query/Common/QueryConverter/NativeQueryConverter.php
 
 		-
-			message: '#^Method Ibexa\\Solr\\Query\\Common\\QueryTranslator\\Generator\\WordVisitor\:\:escapeWord\(\) should return string but returns string\|null\.$#'
-			identifier: return.type
-			count: 1
-			path: src/lib/Query/Common/QueryTranslator/Generator/WordVisitor.php
-
-		-
 			message: '#^Method Ibexa\\Contracts\\Solr\\Query\\SortClauseVisitor\:\:visit\(\) invoked with 2 parameters, 1 required\.$#'
 			identifier: arguments.count
 			count: 1
@@ -1703,48 +1697,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SubtreeAggregationKeyMapperTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\ResultExtractor\\AggregationResultExtractor\\TermAggregationKeyMapper\\UserMetadataAggregationKeyMapperTest\:\:createExpectedResultForUserGroupKey\(\) has parameter \$userGroupsIds with no value type specified in iterable type iterable\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/UserMetadataAggregationKeyMapperTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\ResultExtractor\\AggregationResultExtractor\\TermAggregationKeyMapper\\UserMetadataAggregationKeyMapperTest\:\:createExpectedResultForUserGroupKey\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/UserMetadataAggregationKeyMapperTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\ResultExtractor\\AggregationResultExtractor\\TermAggregationKeyMapper\\UserMetadataAggregationKeyMapperTest\:\:createExpectedResultForUserKey\(\) has parameter \$userIds with no value type specified in iterable type iterable\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/UserMetadataAggregationKeyMapperTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\ResultExtractor\\AggregationResultExtractor\\TermAggregationKeyMapper\\UserMetadataAggregationKeyMapperTest\:\:createExpectedResultForUserKey\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/UserMetadataAggregationKeyMapperTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Solr\\Search\\ResultExtractor\\AggregationResultExtractor\\TermAggregationKeyMapper\\UserMetadataAggregationKeyMapperTest\:\:dataProviderForTestMapUser\(\) return type has no value type specified in iterable type iterable\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/UserMetadataAggregationKeyMapperTest.php
-
-		-
-			message: '#^Parameter \#1 \$aggregation of method Ibexa\\Solr\\ResultExtractor\\AggregationResultExtractor\\TermAggregationKeyMapper\\UserMetadataAggregationKeyMapper\:\:map\(\) expects Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Query\\Aggregation\\UserMetadataTermAggregation, Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Query\\Aggregation given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/UserMetadataAggregationKeyMapperTest.php
-
-		-
-			message: '#^Parameter \#3 \$keys of method Ibexa\\Solr\\ResultExtractor\\AggregationResultExtractor\\TermAggregationKeyMapper\\UserMetadataAggregationKeyMapper\:\:map\(\) expects array\<string\>, array\<int, int\> given\.$#'
-			identifier: argument.type
-			count: 2
-			path: tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/UserMetadataAggregationKeyMapperTest.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\Solr\\Search\\ResultExtractor\\AggregationResultExtractor\\TermAggregationResultExtractorTest\:\:dataProviderForTestCanVisit\(\) return type has no value type specified in iterable type iterable\.$#'

--- a/src/lib/Query/Common/QueryTranslator/Generator/WordVisitor.php
+++ b/src/lib/Query/Common/QueryTranslator/Generator/WordVisitor.php
@@ -16,7 +16,7 @@ use QueryTranslator\Values\Node;
  */
 class WordVisitor extends WordBase
 {
-    public function visit(Node $node, Visitor $subVisitor = null, $options = null)
+    public function visit(Node $node, Visitor $subVisitor = null, $options = null): string
     {
         $word = parent::visit($node, $subVisitor, $options);
 
@@ -29,14 +29,12 @@ class WordVisitor extends WordBase
     }
 
     /**
-     * {@inheritdoc}
-     *
      * @see http://lucene.apache.org/core/5_0_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Escaping_Special_Characters
      *
      * Note: additionally to what is defined above we also escape blank space,
      * and we don't escape an asterisk.
      */
-    protected function escapeWord($string)
+    protected function escapeWord($string): ?string
     {
         return preg_replace(
             '/(\\+|-|&&|\\|\\||!|\\(|\\)|\\{|}|\\[|]|\\^|"|~|\\?|:|\\/|\\\\| )/',

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeGroupAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeGroupAggregationKeyMapperTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 
 final class ContentTypeGroupAggregationKeyMapperTest extends TestCase
 {
-    private const EXAMPLE_CONTENT_TYPE_GROUPS_IDS = ['1', '2', '3'];
+    private const array EXAMPLE_CONTENT_TYPE_GROUPS_IDS = ['1', '2', '3'];
 
     private ContentTypeService&MockObject $contentTypeService;
 
@@ -55,17 +55,17 @@ final class ContentTypeGroupAggregationKeyMapperTest extends TestCase
     {
         $expectedContentTypesGroups = [];
 
-        foreach (self::EXAMPLE_CONTENT_TYPE_GROUPS_IDS as $i => $id) {
+        $map = [];
+        foreach (self::EXAMPLE_CONTENT_TYPE_GROUPS_IDS as $id) {
             $contentTypeGroup = $this->createContentTypeGroupWithIds((int)$id);
-
-            $this->contentTypeService
-                ->expects(self::at($i))
-                ->method('loadContentTypeGroup')
-                ->with((int)$id, [])
-                ->willReturn($contentTypeGroup);
-
             $expectedContentTypesGroups[$id] = $contentTypeGroup;
+
+            $map[] = [(int)$id, [], $contentTypeGroup];
         }
+
+        $this->contentTypeService
+            ->method('loadContentTypeGroup')
+            ->willReturnMap($map);
 
         return $expectedContentTypesGroups;
     }


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|

#### Description:
Added native : string return types to visit() and escapeWord() methods in WordVisitor to prevent PHPStan future warning about missing native return type declarations.

Updated UserMetadataAggregationKeyMapperTest to:
- type-hint $aggregation parameter as UserMetadataTermAggregation (not general Aggregation)
- convert user ID keys to strings before passing to map() method, matching expected array<string> type.
- This improves type safety and eliminates PHPStan errors/warnings during test runs.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
