### PR TITLE
IBX-10254: Renamed ez_lock object state group to ibexa_lock

### DIFF
--- a/tests/lib/Search/Query/Common/AggregationVisitor/ObjectStateGroupAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/ObjectStateGroupAggregationVisitorTest.php
@@ -23,7 +23,7 @@ final class ObjectStateGroupAggregationVisitorTest extends AbstractAggregationVi
     public function dataProviderForCanVisit(): iterable
     {
         yield 'true' => [
-            new ObjectStateTermAggregation('foo', 'ez_lock'),
+            new ObjectStateTermAggregation('foo', 'ibexa_lock'),
             self::EXAMPLE_LANGUAGE_FILTER,
             true,
         ];
@@ -38,18 +38,18 @@ final class ObjectStateGroupAggregationVisitorTest extends AbstractAggregationVi
     public function dataProviderForVisit(): iterable
     {
         yield 'defaults' => [
-            new ObjectStateTermAggregation('foo', 'ez_lock'),
+            new ObjectStateTermAggregation('foo', 'ibexa_lock'),
             self::EXAMPLE_LANGUAGE_FILTER,
             [
                 'type' => 'terms',
                 'field' => 'content_object_state_identifiers_ms',
-                'prefix' => 'ez_lock:',
+                'prefix' => 'ibexa_lock:',
                 'limit' => ObjectStateTermAggregation::DEFAULT_LIMIT,
                 'mincount' => ObjectStateTermAggregation::DEFAULT_MIN_COUNT,
             ],
         ];
 
-        $aggregation = new ObjectStateTermAggregation('foo', 'ez_lock');
+        $aggregation = new ObjectStateTermAggregation('foo', 'ibexa_lock');
         $aggregation->setLimit(100);
         $aggregation->setMinCount(10);
 
@@ -59,7 +59,7 @@ final class ObjectStateGroupAggregationVisitorTest extends AbstractAggregationVi
             [
                 'type' => 'terms',
                 'field' => 'content_object_state_identifiers_ms',
-                'prefix' => 'ez_lock:',
+                'prefix' => 'ibexa_lock:',
                 'limit' => 100,
                 'mincount' => 10,
             ],

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ObjectStateAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ObjectStateAggregationKeyMapperTest.php
@@ -33,16 +33,16 @@ final class ObjectStateAggregationKeyMapperTest extends TestCase
     public function testMap(): void
     {
         $expectedObjectStates = array_combine(
-            ['ez_lock:unlocked', 'ez_lock:locked'],
-            $this->configureObjectStateService('ez_lock', ['unlocked', 'locked'])
+            ['ibexa_lock:unlocked', 'ibexa_lock:locked'],
+            $this->configureObjectStateService('ibexa_lock', ['unlocked', 'locked'])
         );
 
         self::assertEquals(
             $expectedObjectStates,
             $this->mapper->map(
-                new ObjectStateTermAggregation('aggregation', 'ez_lock'),
+                new ObjectStateTermAggregation('aggregation', 'ibexa_lock'),
                 AggregationResultExtractorTestUtils::EXAMPLE_LANGUAGE_FILTER,
-                ['ez_lock:unlocked', 'ez_lock:locked']
+                ['ibexa_lock:unlocked', 'ibexa_lock:locked']
             )
         );
     }


### PR DESCRIPTION
| :ticket: Issue | IBX-10254 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Renamed `ez_lock` object state group to `ibexa_lock`. This change doesn't not affect existing projects. 

#### For QA:
N/A

#### Documentation:
Replace `ez_lock` mentions.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
